### PR TITLE
feat: drag-resize table columns with localStorage persistence

### DIFF
--- a/docs/superpowers/plans/2026-04-20-column-actions.md
+++ b/docs/superpowers/plans/2026-04-20-column-actions.md
@@ -1,0 +1,900 @@
+# Column Actions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an accessible actions popover to each resizable column header with sort toggles and a resize-by-number-input dialog.
+
+**Architecture:** Two new co-located components: `ColumnActionsPopover` (Base UI Popover with sort toggle buttons and a Resize… trigger) and `ColumnResizeDialog` (Base UI Dialog with a `<input type="number">`). `SearchResults` gains `resizeTarget` state to bridge the two and renders both alongside the existing sort button and drag handle.
+
+**Tech Stack:** `@base-ui/react` Popover and Dialog, React `useState`, CSS Modules, `@testing-library/react`, `userEvent`.
+
+---
+
+## File Structure
+
+| File                                                           | Action | Responsibility                                                                                         |
+| -------------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------ |
+| `src/components/SearchResults/ColumnActionsPopover.tsx`        | Create | Kebab button + Base UI Popover with sort toggles and Resize… button                                    |
+| `src/components/SearchResults/ColumnActionsPopover.module.css` | Create | Popover trigger, popup, and action button styles                                                       |
+| `src/components/SearchResults/ColumnActionsPopover.test.tsx`   | Create | Unit tests for the popover                                                                             |
+| `src/components/SearchResults/ColumnResizeDialog.tsx`          | Create | Base UI Dialog with number input                                                                       |
+| `src/components/SearchResults/ColumnResizeDialog.module.css`   | Create | Dialog backdrop, popup, input, and button styles                                                       |
+| `src/components/SearchResults/ColumnResizeDialog.test.tsx`     | Create | Unit tests for the dialog                                                                              |
+| `src/components/SearchResults/SearchResults.tsx`               | Modify | Add `resizeTarget` state, import and render both new components                                        |
+| `src/components/SearchResults/SearchResults.module.css`        | Modify | Add `padding-right` to `.resizableTh` to make room for the kebab button                                |
+| `src/components/SearchResults/SearchResults.test.tsx`          | Modify | Integration tests: actions button present, popover opens, dialog opens, Apply persists to localStorage |
+
+---
+
+### Task 1: `ColumnActionsPopover`
+
+**Files:**
+
+- Create: `src/components/SearchResults/ColumnActionsPopover.tsx`
+- Create: `src/components/SearchResults/ColumnActionsPopover.module.css`
+- Create: `src/components/SearchResults/ColumnActionsPopover.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/components/SearchResults/ColumnActionsPopover.test.tsx`:
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+import { ColumnActionsPopover } from "./ColumnActionsPopover";
+
+function renderPopover(
+  overrides: Partial<React.ComponentProps<typeof ColumnActionsPopover>> = {},
+) {
+  return render(
+    <ColumnActionsPopover
+      sortField="title"
+      activeSortField={undefined}
+      activeSortDir={undefined}
+      onSort={vi.fn()}
+      onOpenResize={vi.fn()}
+      {...overrides}
+    />,
+  );
+}
+
+test("renders a column actions button", () => {
+  renderPopover();
+  expect(
+    screen.getByRole("button", { name: "Column actions" }),
+  ).toBeInTheDocument();
+});
+
+test("opens popover with sort and resize actions when clicked", async () => {
+  const user = userEvent.setup();
+  renderPopover();
+  await user.click(screen.getByRole("button", { name: "Column actions" }));
+  expect(
+    screen.getByRole("button", { name: "Sort ascending" }),
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole("button", { name: "Sort descending" }),
+  ).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: "Resize…" })).toBeInTheDocument();
+});
+
+test("Sort ascending has aria-pressed=false when column is unsorted", async () => {
+  const user = userEvent.setup();
+  renderPopover({ activeSortField: undefined });
+  await user.click(screen.getByRole("button", { name: "Column actions" }));
+  expect(
+    screen.getByRole("button", { name: "Sort ascending" }),
+  ).toHaveAttribute("aria-pressed", "false");
+});
+
+test("Sort ascending has aria-pressed=true when column is sorted ascending", async () => {
+  const user = userEvent.setup();
+  renderPopover({ activeSortField: "title", activeSortDir: "asc" });
+  await user.click(screen.getByRole("button", { name: "Column actions" }));
+  expect(
+    screen.getByRole("button", { name: "Sort ascending" }),
+  ).toHaveAttribute("aria-pressed", "true");
+});
+
+test("Sort descending has aria-pressed=true when column is sorted descending", async () => {
+  const user = userEvent.setup();
+  renderPopover({ activeSortField: "title", activeSortDir: "desc" });
+  await user.click(screen.getByRole("button", { name: "Column actions" }));
+  expect(
+    screen.getByRole("button", { name: "Sort descending" }),
+  ).toHaveAttribute("aria-pressed", "true");
+});
+
+test("clicking Sort ascending when unsorted calls onSort with field.asc", async () => {
+  const user = userEvent.setup();
+  const onSort = vi.fn();
+  renderPopover({ onSort });
+  await user.click(screen.getByRole("button", { name: "Column actions" }));
+  await user.click(screen.getByRole("button", { name: "Sort ascending" }));
+  expect(onSort).toHaveBeenCalledWith("title.asc");
+});
+
+test("clicking Sort ascending when already ascending calls onSort with undefined", async () => {
+  const user = userEvent.setup();
+  const onSort = vi.fn();
+  renderPopover({ activeSortField: "title", activeSortDir: "asc", onSort });
+  await user.click(screen.getByRole("button", { name: "Column actions" }));
+  await user.click(screen.getByRole("button", { name: "Sort ascending" }));
+  expect(onSort).toHaveBeenCalledWith(undefined);
+});
+
+test("clicking Sort descending when ascending calls onSort with field.desc", async () => {
+  const user = userEvent.setup();
+  const onSort = vi.fn();
+  renderPopover({ activeSortField: "title", activeSortDir: "asc", onSort });
+  await user.click(screen.getByRole("button", { name: "Column actions" }));
+  await user.click(screen.getByRole("button", { name: "Sort descending" }));
+  expect(onSort).toHaveBeenCalledWith("title.desc");
+});
+
+test("clicking Resize… calls onOpenResize", async () => {
+  const user = userEvent.setup();
+  const onOpenResize = vi.fn();
+  renderPopover({ onOpenResize });
+  await user.click(screen.getByRole("button", { name: "Column actions" }));
+  await user.click(screen.getByRole("button", { name: "Resize…" }));
+  expect(onOpenResize).toHaveBeenCalledTimes(1);
+});
+
+test("does not render sort buttons when sortField is undefined", async () => {
+  const user = userEvent.setup();
+  renderPopover({ sortField: undefined });
+  await user.click(screen.getByRole("button", { name: "Column actions" }));
+  expect(
+    screen.queryByRole("button", { name: "Sort ascending" }),
+  ).not.toBeInTheDocument();
+  expect(
+    screen.queryByRole("button", { name: "Sort descending" }),
+  ).not.toBeInTheDocument();
+  expect(screen.getByRole("button", { name: "Resize…" })).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd /home/myasonik/Workspace/Gen-Con-Buddy-column-resize && npx vitest run src/components/SearchResults/ColumnActionsPopover.test.tsx
+```
+
+Expected: FAIL — `ColumnActionsPopover` does not exist.
+
+- [ ] **Step 3: Create the CSS module**
+
+Create `src/components/SearchResults/ColumnActionsPopover.module.css`:
+
+```css
+/* Absolutely positioned within the resizable <th> (which has position: relative) */
+.trigger {
+  position: absolute;
+  right: 6px; /* sits left of the 4px drag handle */
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  padding: 2px;
+  cursor: pointer;
+  color: var(--color-parchment);
+  opacity: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 2px;
+  transition: opacity var(--motion-hover);
+}
+
+/* Show on header hover or when the popover is open */
+:global(th):hover .trigger,
+.trigger:focus-visible,
+.triggerOpen {
+  opacity: 1;
+}
+
+.trigger:focus-visible {
+  outline: 2px solid var(--color-gold);
+  outline-offset: 1px;
+}
+
+.popup {
+  background: var(--color-parchment-light);
+  border: 2px solid var(--color-bark);
+  box-shadow: var(--shadow-panel);
+  display: flex;
+  flex-direction: column;
+  min-width: 148px;
+  z-index: var(--z-popover);
+}
+
+.action {
+  background: none;
+  border: none;
+  border-bottom: 1px solid var(--color-bark-light);
+  padding: var(--space-2) var(--space-3);
+  font-family: var(--font-display);
+  font-size: var(--text-label);
+  font-style: italic;
+  color: var(--color-ink);
+  cursor: pointer;
+  text-align: left;
+  width: 100%;
+}
+
+.action:last-child {
+  border-bottom: none;
+}
+
+.action:hover {
+  background: color-mix(
+    in srgb,
+    var(--color-bark-light) 20%,
+    var(--color-parchment-light)
+  );
+}
+
+.action[aria-pressed="true"] {
+  color: var(--color-bark);
+  font-weight: bold;
+}
+```
+
+- [ ] **Step 4: Implement `ColumnActionsPopover`**
+
+Create `src/components/SearchResults/ColumnActionsPopover.tsx`:
+
+```tsx
+import { useState } from "react";
+import { Popover } from "@base-ui/react/popover";
+import styles from "./ColumnActionsPopover.module.css";
+
+interface ColumnActionsPopoverProps {
+  sortField: string | undefined;
+  activeSortField: string | undefined;
+  activeSortDir: "asc" | "desc" | undefined;
+  onSort: (sort: string | undefined) => void;
+  onOpenResize: () => void;
+}
+
+export function ColumnActionsPopover({
+  sortField,
+  activeSortField,
+  activeSortDir,
+  onSort,
+  onOpenResize,
+}: ColumnActionsPopoverProps) {
+  const [open, setOpen] = useState(false);
+
+  const isSortedAsc =
+    !!sortField && activeSortField === sortField && activeSortDir === "asc";
+  const isSortedDesc =
+    !!sortField && activeSortField === sortField && activeSortDir === "desc";
+
+  return (
+    <Popover.Root open={open} onOpenChange={setOpen}>
+      <Popover.Trigger
+        className={`${styles.trigger}${open ? ` ${styles.triggerOpen}` : ""}`}
+        aria-label="Column actions"
+      >
+        <svg
+          width="12"
+          height="12"
+          viewBox="0 0 12 12"
+          aria-hidden="true"
+          focusable="false"
+        >
+          <circle cx="6" cy="2" r="1.5" fill="currentColor" />
+          <circle cx="6" cy="6" r="1.5" fill="currentColor" />
+          <circle cx="6" cy="10" r="1.5" fill="currentColor" />
+        </svg>
+      </Popover.Trigger>
+      <Popover.Portal>
+        <Popover.Positioner sideOffset={4}>
+          <Popover.Popup className={styles.popup}>
+            {sortField && (
+              <>
+                <button
+                  type="button"
+                  className={styles.action}
+                  aria-pressed={isSortedAsc}
+                  onClick={() => {
+                    onSort(isSortedAsc ? undefined : `${sortField}.asc`);
+                    setOpen(false);
+                  }}
+                >
+                  Sort ascending
+                </button>
+                <button
+                  type="button"
+                  className={styles.action}
+                  aria-pressed={isSortedDesc}
+                  onClick={() => {
+                    onSort(isSortedDesc ? undefined : `${sortField}.desc`);
+                    setOpen(false);
+                  }}
+                >
+                  Sort descending
+                </button>
+              </>
+            )}
+            <button
+              type="button"
+              className={styles.action}
+              onClick={() => {
+                setOpen(false);
+                onOpenResize();
+              }}
+            >
+              Resize…
+            </button>
+          </Popover.Popup>
+        </Popover.Positioner>
+      </Popover.Portal>
+    </Popover.Root>
+  );
+}
+```
+
+- [ ] **Step 5: Run tests and verify they pass**
+
+```bash
+npx vitest run src/components/SearchResults/ColumnActionsPopover.test.tsx
+```
+
+Expected: all 10 tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/SearchResults/ColumnActionsPopover.tsx src/components/SearchResults/ColumnActionsPopover.module.css src/components/SearchResults/ColumnActionsPopover.test.tsx
+git commit -m "feat(ColumnActionsPopover): add popover with sort toggles and resize action"
+```
+
+---
+
+### Task 2: `ColumnResizeDialog`
+
+**Files:**
+
+- Create: `src/components/SearchResults/ColumnResizeDialog.tsx`
+- Create: `src/components/SearchResults/ColumnResizeDialog.module.css`
+- Create: `src/components/SearchResults/ColumnResizeDialog.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/components/SearchResults/ColumnResizeDialog.test.tsx`:
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+import { ColumnResizeDialog } from "./ColumnResizeDialog";
+
+test("renders with the column name in the heading", () => {
+  render(
+    <ColumnResizeDialog
+      columnName="Title"
+      currentWidth={150}
+      onApply={vi.fn()}
+      onClose={vi.fn()}
+    />,
+  );
+  expect(
+    screen.getByRole("heading", { name: "Resize Title" }),
+  ).toBeInTheDocument();
+});
+
+test("pre-fills the number input with currentWidth", () => {
+  render(
+    <ColumnResizeDialog
+      columnName="Title"
+      currentWidth={200}
+      onApply={vi.fn()}
+      onClose={vi.fn()}
+    />,
+  );
+  expect(screen.getByRole("spinbutton", { name: "Width (px)" })).toHaveValue(
+    200,
+  );
+});
+
+test("clicking Apply calls onApply with the parsed number value", async () => {
+  const user = userEvent.setup();
+  const onApply = vi.fn();
+  render(
+    <ColumnResizeDialog
+      columnName="Title"
+      currentWidth={150}
+      onApply={onApply}
+      onClose={vi.fn()}
+    />,
+  );
+  const input = screen.getByRole("spinbutton", { name: "Width (px)" });
+  await user.clear(input);
+  await user.type(input, "300");
+  await user.click(screen.getByRole("button", { name: "Apply" }));
+  expect(onApply).toHaveBeenCalledWith(300);
+});
+
+test("clicking Cancel calls onClose without calling onApply", async () => {
+  const user = userEvent.setup();
+  const onApply = vi.fn();
+  const onClose = vi.fn();
+  render(
+    <ColumnResizeDialog
+      columnName="Title"
+      currentWidth={150}
+      onApply={onApply}
+      onClose={onClose}
+    />,
+  );
+  await user.click(screen.getByRole("button", { name: "Cancel" }));
+  expect(onClose).toHaveBeenCalledTimes(1);
+  expect(onApply).not.toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npx vitest run src/components/SearchResults/ColumnResizeDialog.test.tsx
+```
+
+Expected: FAIL — `ColumnResizeDialog` does not exist.
+
+- [ ] **Step 3: Create the CSS module**
+
+Create `src/components/SearchResults/ColumnResizeDialog.module.css`:
+
+```css
+.backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(59, 30, 10, 0.35);
+  z-index: calc(var(--z-modal) - 1);
+}
+
+.popup {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: var(--color-parchment-light);
+  border: 2px solid var(--color-bark);
+  box-shadow: var(--shadow-panel);
+  padding: var(--space-4);
+  min-width: 260px;
+  z-index: var(--z-modal);
+}
+
+.title {
+  font-family: var(--font-display);
+  font-size: var(--text-heading);
+  font-style: italic;
+  color: var(--color-bark);
+  margin: 0 0 var(--space-3);
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  margin-bottom: var(--space-4);
+}
+
+.label {
+  font-family: var(--font-display);
+  font-size: var(--text-label);
+  font-style: italic;
+  color: var(--color-ink);
+}
+
+.input {
+  font-family: var(--font-data);
+  font-size: var(--text-small);
+  border: 2px solid var(--color-bark);
+  padding: var(--space-1) var(--space-2);
+  background: var(--color-parchment);
+  color: var(--color-ink);
+  width: 100%;
+}
+
+.input:focus {
+  outline: 2px solid var(--color-gold);
+  outline-offset: 1px;
+}
+
+.actions {
+  display: flex;
+  gap: var(--space-2);
+  justify-content: flex-end;
+}
+
+.button {
+  font-family: var(--font-display);
+  font-size: var(--text-label);
+  font-style: italic;
+  background: var(--color-parchment);
+  border: 2px solid var(--color-bark);
+  color: var(--color-bark);
+  padding: var(--space-1) var(--space-3);
+  cursor: pointer;
+}
+
+.button:hover {
+  background: var(--color-bark-light);
+  color: var(--color-parchment-light);
+}
+
+.primaryButton {
+  background: var(--color-bark);
+  color: var(--color-parchment-light);
+}
+
+.primaryButton:hover {
+  background: var(--color-bark-dark);
+}
+```
+
+- [ ] **Step 4: Implement `ColumnResizeDialog`**
+
+Create `src/components/SearchResults/ColumnResizeDialog.tsx`:
+
+```tsx
+import { useState } from "react";
+import { Dialog } from "@base-ui/react/dialog";
+import styles from "./ColumnResizeDialog.module.css";
+
+interface ColumnResizeDialogProps {
+  columnName: string;
+  currentWidth: number;
+  onApply: (width: number) => void;
+  onClose: () => void;
+}
+
+export function ColumnResizeDialog({
+  columnName,
+  currentWidth,
+  onApply,
+  onClose,
+}: ColumnResizeDialogProps) {
+  const [value, setValue] = useState(String(currentWidth));
+
+  return (
+    <Dialog.Root
+      open={true}
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <Dialog.Portal>
+        <Dialog.Backdrop className={styles.backdrop} />
+        <Dialog.Popup className={styles.popup}>
+          <Dialog.Title className={styles.title}>
+            Resize {columnName}
+          </Dialog.Title>
+          <div className={styles.field}>
+            <label htmlFor="resize-width-input" className={styles.label}>
+              Width (px)
+            </label>
+            <input
+              id="resize-width-input"
+              type="number"
+              className={styles.input}
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+            />
+          </div>
+          <div className={styles.actions}>
+            <button type="button" className={styles.button} onClick={onClose}>
+              Cancel
+            </button>
+            <button
+              type="button"
+              className={`${styles.button} ${styles.primaryButton}`}
+              onClick={() => onApply(Number(value))}
+            >
+              Apply
+            </button>
+          </div>
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}
+```
+
+- [ ] **Step 5: Run tests and verify they pass**
+
+```bash
+npx vitest run src/components/SearchResults/ColumnResizeDialog.test.tsx
+```
+
+Expected: all 4 tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/SearchResults/ColumnResizeDialog.tsx src/components/SearchResults/ColumnResizeDialog.module.css src/components/SearchResults/ColumnResizeDialog.test.tsx
+git commit -m "feat(ColumnResizeDialog): add modal dialog for setting column width by number"
+```
+
+---
+
+### Task 3: Wire into `SearchResults` + CSS + integration tests
+
+**Files:**
+
+- Modify: `src/components/SearchResults/SearchResults.tsx`
+- Modify: `src/components/SearchResults/SearchResults.module.css`
+- Modify: `src/components/SearchResults/SearchResults.test.tsx`
+
+- [ ] **Step 1: Write the failing integration tests**
+
+Append to `src/components/SearchResults/SearchResults.test.tsx`:
+
+```tsx
+test("actions button is present on resizable columns", async () => {
+  renderSearchResults();
+  await screen.findAllByRole("row");
+  const actionButtons = screen.getAllByRole("button", {
+    name: "Column actions",
+  });
+  expect(actionButtons.length).toBeGreaterThan(0);
+});
+
+test("actions button is absent on dayStripe column", async () => {
+  renderSearchResults();
+  await screen.findAllByRole("row");
+  const dayStripes = document.querySelectorAll("th[aria-hidden='true']");
+  dayStripes.forEach((th) => {
+    expect(th.querySelector("[aria-label='Column actions']")).toBeNull();
+  });
+});
+
+test("clicking Resize… on a column opens the resize dialog", async () => {
+  const user = userEvent.setup();
+  renderSearchResults();
+  await screen.findAllByRole("row");
+  const titleTh = screen.getByRole("columnheader", { name: "Title" });
+  await user.click(
+    within(titleTh).getByRole("button", { name: "Column actions" }),
+  );
+  await user.click(screen.getByRole("button", { name: "Resize…" }));
+  expect(screen.getByRole("dialog")).toBeInTheDocument();
+});
+
+test("submitting resize dialog updates column width in localStorage", async () => {
+  const user = userEvent.setup();
+  renderSearchResults();
+  await screen.findAllByRole("row");
+  const titleTh = screen.getByRole("columnheader", { name: "Title" });
+  await user.click(
+    within(titleTh).getByRole("button", { name: "Column actions" }),
+  );
+  await user.click(screen.getByRole("button", { name: "Resize…" }));
+  const input = screen.getByRole("spinbutton", { name: "Width (px)" });
+  await user.clear(input);
+  await user.type(input, "400");
+  await user.click(screen.getByRole("button", { name: "Apply" }));
+  const stored = JSON.parse(localStorage.getItem("gcb-column-sizing")!);
+  expect(stored).toEqual({ version: 1, sizing: { title: 400 } });
+});
+```
+
+Also add `within` to the import at the top of the test file. The existing import is:
+
+```tsx
+import { render, screen, waitFor } from "@testing-library/react";
+```
+
+Change it to:
+
+```tsx
+import { render, screen, waitFor, within } from "@testing-library/react";
+```
+
+- [ ] **Step 2: Run new tests to verify they fail**
+
+```bash
+npx vitest run src/components/SearchResults/SearchResults.test.tsx --reporter=verbose 2>&1 | tail -20
+```
+
+Expected: the 4 new tests FAIL (actions buttons not yet rendered).
+
+- [ ] **Step 3: Update `SearchResults.module.css` — add padding-right to `.resizableTh`**
+
+In `src/components/SearchResults/SearchResults.module.css`, find the `.resizableTh` rule and add `padding-right`:
+
+```css
+/* Column resize handle */
+.resizableTh {
+  position: relative;
+  padding-right: 26px; /* room for kebab actions button (20px) + drag handle (4px) + 2px gap */
+}
+```
+
+- [ ] **Step 4: Update `SearchResults.tsx` — imports and state**
+
+At the top of `src/components/SearchResults/SearchResults.tsx`, add `useState` to the React import and add the two new component imports after the `useColumnSizing` import:
+
+Change:
+
+```tsx
+import {
+  useReactTable,
+  getCoreRowModel,
+  flexRender,
+} from "@tanstack/react-table";
+import type { ColumnDef } from "@tanstack/react-table";
+```
+
+To:
+
+```tsx
+import { useState } from "react";
+import {
+  useReactTable,
+  getCoreRowModel,
+  flexRender,
+} from "@tanstack/react-table";
+import type { ColumnDef } from "@tanstack/react-table";
+```
+
+After the `useColumnSizing` import line, add:
+
+```tsx
+import { ColumnActionsPopover } from "./ColumnActionsPopover";
+import { ColumnResizeDialog } from "./ColumnResizeDialog";
+```
+
+- [ ] **Step 5: Add `resizeTarget` state inside `SearchResults`**
+
+Inside the `SearchResults` function body, after the `const { sizing, setSizing, reset: resetSizing } = useColumnSizing();` line, add:
+
+```tsx
+const [resizeTarget, setResizeTarget] = useState<{
+  columnId: string;
+  columnName: string;
+  currentWidth: number;
+} | null>(null);
+```
+
+- [ ] **Step 6: Render `ColumnActionsPopover` inside each resizable `<th>`**
+
+Find the section inside the `<th>` that renders the sort button and resize handle (around lines 449–476 of the current file). Change it from:
+
+```tsx
+<button
+  type="button"
+  aria-label={`Sort by ${label}`}
+  onClick={() => sortField && handleSortClick(sortField, label)}
+>
+  {flexRender(header.column.columnDef.header, header.getContext())}
+  {isActive && (
+    <span aria-hidden="true" className={styles.sortIndicator}>
+      {activeSortDir === "asc" ? " ▲" : " ▼"}
+    </span>
+  )}
+</button>;
+{
+  header.column.getCanResize() && (
+    <div
+      className={styles.resizeHandle}
+      onPointerDown={header.getResizeHandler()}
+      aria-hidden="true"
+      data-testid="resize-handle"
+    />
+  );
+}
+```
+
+To:
+
+```tsx
+<button
+  type="button"
+  aria-label={`Sort by ${label}`}
+  onClick={() => sortField && handleSortClick(sortField, label)}
+>
+  {flexRender(header.column.columnDef.header, header.getContext())}
+  {isActive && (
+    <span aria-hidden="true" className={styles.sortIndicator}>
+      {activeSortDir === "asc" ? " ▲" : " ▼"}
+    </span>
+  )}
+</button>;
+{
+  header.column.getCanResize() && (
+    <ColumnActionsPopover
+      sortField={sortField}
+      activeSortField={activeSortField}
+      activeSortDir={activeSortDir}
+      onSort={onSort}
+      onOpenResize={() =>
+        setResizeTarget({
+          columnId: header.column.id,
+          columnName: label,
+          currentWidth: header.getSize(),
+        })
+      }
+    />
+  );
+}
+{
+  header.column.getCanResize() && (
+    <div
+      className={styles.resizeHandle}
+      onPointerDown={header.getResizeHandler()}
+      aria-hidden="true"
+      data-testid="resize-handle"
+    />
+  );
+}
+```
+
+- [ ] **Step 7: Render `ColumnResizeDialog` at the end of the `<section>`**
+
+Find the closing `</section>` tag at the end of the `SearchResults` return. Change:
+
+```tsx
+    </section>
+  );
+}
+```
+
+To:
+
+```tsx
+      {resizeTarget && (
+        <ColumnResizeDialog
+          columnName={resizeTarget.columnName}
+          currentWidth={resizeTarget.currentWidth}
+          onApply={(width) => {
+            setSizing((prev) => ({
+              ...prev,
+              [resizeTarget.columnId]: width,
+            }));
+            setResizeTarget(null);
+          }}
+          onClose={() => setResizeTarget(null)}
+        />
+      )}
+    </section>
+  );
+}
+```
+
+- [ ] **Step 8: Verify TypeScript compiles cleanly**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 9: Run the full integration tests**
+
+```bash
+npx vitest run src/components/SearchResults/SearchResults.test.tsx
+```
+
+Expected: all 38 tests PASS (34 existing + 4 new).
+
+- [ ] **Step 10: Run the full test suite**
+
+```bash
+npx vitest run
+```
+
+Expected: all 264 tests PASS (250 baseline + 10 ColumnActionsPopover + 4 ColumnResizeDialog).
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add src/components/SearchResults/SearchResults.tsx src/components/SearchResults/SearchResults.module.css src/components/SearchResults/SearchResults.test.tsx
+git commit -m "feat(SearchResults): wire ColumnActionsPopover and ColumnResizeDialog into column headers"
+```

--- a/docs/superpowers/plans/2026-04-20-column-resize.md
+++ b/docs/superpowers/plans/2026-04-20-column-resize.md
@@ -1,0 +1,513 @@
+# Column Resizing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users drag-resize table columns in SearchResults, with widths persisted to localStorage and reset by the existing "Reset to defaults" button.
+
+**Architecture:** A new `useColumnSizing` hook (mirroring `useColumnVisibility`) manages `ColumnSizingState` in localStorage. It is wired into `useReactTable` alongside the existing visibility state. Each resizable `<th>` renders a drag handle that calls TanStack's `header.getResizeHandler()`. The `dayStripe` column is excluded from resizing via `enableResizing: false`.
+
+**Tech Stack:** TanStack React Table v8 (`columnResizeMode`, `ColumnSizingState`, `OnChangeFn`), React, CSS Modules, `@testing-library/react` `renderHook`.
+
+---
+
+## File Structure
+
+| File                                                    | Action | Responsibility                                                        |
+| ------------------------------------------------------- | ------ | --------------------------------------------------------------------- |
+| `src/hooks/useColumnSizing.ts`                          | Create | Column sizing state + localStorage persistence                        |
+| `src/hooks/useColumnSizing.test.ts`                     | Create | Unit tests for the hook                                               |
+| `src/components/SearchResults/SearchResults.tsx`        | Modify | Wire sizing into `useReactTable`, render handles, update Reset button |
+| `src/components/SearchResults/SearchResults.module.css` | Modify | Resize handle styles                                                  |
+| `src/components/SearchResults/SearchResults.test.tsx`   | Modify | Integration tests for resize handle rendering and localStorage        |
+
+---
+
+### Task 1: `useColumnSizing` hook
+
+**Files:**
+
+- Create: `src/hooks/useColumnSizing.ts`
+- Create: `src/hooks/useColumnSizing.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/hooks/useColumnSizing.test.ts`:
+
+```ts
+import { renderHook, act } from "@testing-library/react";
+import { useColumnSizing } from "./useColumnSizing";
+
+const STORAGE_KEY = "gcb-column-sizing";
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+test("returns empty sizing on first use", () => {
+  const { result } = renderHook(() => useColumnSizing());
+  expect(result.current.sizing).toEqual({});
+});
+
+test("setSizing with a value updates state", () => {
+  const { result } = renderHook(() => useColumnSizing());
+
+  act(() => {
+    result.current.setSizing({ title: 300 });
+  });
+
+  expect(result.current.sizing).toEqual({ title: 300 });
+});
+
+test("setSizing with an updater function updates state", () => {
+  const { result } = renderHook(() => useColumnSizing());
+
+  act(() => {
+    result.current.setSizing({ title: 200 });
+  });
+  act(() => {
+    result.current.setSizing((prev) => ({ ...prev, gameId: 100 }));
+  });
+
+  expect(result.current.sizing).toEqual({ title: 200, gameId: 100 });
+});
+
+test("persists sizing to localStorage", () => {
+  const { result } = renderHook(() => useColumnSizing());
+
+  act(() => {
+    result.current.setSizing({ title: 300 });
+  });
+
+  const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+  expect(stored).toEqual({ version: 1, sizing: { title: 300 } });
+});
+
+test("loads sizing from localStorage on mount", () => {
+  localStorage.setItem(
+    STORAGE_KEY,
+    JSON.stringify({ version: 1, sizing: { title: 300, gameId: 150 } }),
+  );
+
+  const { result } = renderHook(() => useColumnSizing());
+  expect(result.current.sizing).toEqual({ title: 300, gameId: 150 });
+});
+
+test("returns empty sizing when stored version does not match", () => {
+  localStorage.setItem(
+    STORAGE_KEY,
+    JSON.stringify({ version: 9999, sizing: { title: 300 } }),
+  );
+
+  const { result } = renderHook(() => useColumnSizing());
+  expect(result.current.sizing).toEqual({});
+});
+
+test("returns empty sizing when localStorage is malformed", () => {
+  localStorage.setItem(STORAGE_KEY, "not-json{{{");
+
+  const { result } = renderHook(() => useColumnSizing());
+  expect(result.current.sizing).toEqual({});
+});
+
+test("reset clears sizing state and removes localStorage key", () => {
+  const { result } = renderHook(() => useColumnSizing());
+
+  act(() => {
+    result.current.setSizing({ title: 300 });
+  });
+
+  expect(result.current.sizing).toEqual({ title: 300 });
+
+  act(() => {
+    result.current.reset();
+  });
+
+  expect(result.current.sizing).toEqual({});
+  expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+npx vitest run src/hooks/useColumnSizing.test.ts
+```
+
+Expected: FAIL — `useColumnSizing` does not exist.
+
+- [ ] **Step 3: Implement the hook**
+
+Create `src/hooks/useColumnSizing.ts`:
+
+```ts
+import { useState, useEffect } from "react";
+import type { ColumnSizingState, OnChangeFn } from "@tanstack/react-table";
+
+const STORAGE_KEY = "gcb-column-sizing";
+const VERSION = 1;
+
+function readFromStorage(): ColumnSizingState {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      (parsed as { version?: unknown }).version !== VERSION
+    ) {
+      return {};
+    }
+    return (parsed as { version: number; sizing: ColumnSizingState }).sizing;
+  } catch {
+    return {};
+  }
+}
+
+export function useColumnSizing() {
+  const [sizing, setSizingState] = useState<ColumnSizingState>(readFromStorage);
+
+  useEffect(() => {
+    if (Object.keys(sizing).length === 0) {
+      localStorage.removeItem(STORAGE_KEY);
+    } else {
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({ version: VERSION, sizing }),
+      );
+    }
+  }, [sizing]);
+
+  const setSizing: OnChangeFn<ColumnSizingState> = (updaterOrValue) => {
+    setSizingState((prev) =>
+      typeof updaterOrValue === "function"
+        ? updaterOrValue(prev)
+        : updaterOrValue,
+    );
+  };
+
+  const reset = () => {
+    setSizingState({});
+  };
+
+  return { sizing, setSizing, reset };
+}
+```
+
+- [ ] **Step 4: Run the tests and verify they pass**
+
+```bash
+npx vitest run src/hooks/useColumnSizing.test.ts
+```
+
+Expected: all 8 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hooks/useColumnSizing.ts src/hooks/useColumnSizing.test.ts
+git commit -m "feat(useColumnSizing): add hook for column sizing with localStorage persistence"
+```
+
+---
+
+### Task 2: Resize handle CSS
+
+**Files:**
+
+- Modify: `src/components/SearchResults/SearchResults.module.css`
+
+- [ ] **Step 1: Add resize handle styles**
+
+Append to the end of `src/components/SearchResults/SearchResults.module.css`:
+
+```css
+/* Column resize handle */
+.resizableTh {
+  position: relative;
+}
+
+.resizeHandle {
+  position: absolute;
+  right: 0;
+  top: 0;
+  height: 100%;
+  width: 4px;
+  cursor: col-resize;
+  background: transparent;
+  opacity: 0;
+  transition: opacity 100ms;
+  user-select: none;
+}
+
+.resizableTh:hover .resizeHandle,
+.isResizing .resizeHandle {
+  opacity: 1;
+  background: var(--color-gold);
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/components/SearchResults/SearchResults.module.css
+git commit -m "feat(SearchResults): add resize handle styles"
+```
+
+---
+
+### Task 3: Wire sizing into SearchResults and render handles
+
+**Files:**
+
+- Modify: `src/components/SearchResults/SearchResults.tsx`
+
+- [ ] **Step 1: Update the `dayStripe` column def to disable resizing**
+
+In `src/components/SearchResults/SearchResults.tsx`, the `dayStripe` column def (lines 36–40) currently is:
+
+```ts
+{
+  id: "dayStripe",
+  header: () => null,
+  cell: () => null,
+},
+```
+
+Change it to:
+
+```ts
+{
+  id: "dayStripe",
+  header: () => null,
+  cell: () => null,
+  enableResizing: false,
+},
+```
+
+- [ ] **Step 2: Import `useColumnSizing`**
+
+At the top of `SearchResults.tsx`, after the `useColumnVisibility` import, add:
+
+```ts
+import { useColumnSizing } from "../../hooks/useColumnSizing";
+```
+
+- [ ] **Step 3: Instantiate the hook and wire it into `useReactTable`**
+
+After the existing `const { visibility, toggle, reset } = useColumnVisibility();` line, add:
+
+```ts
+const { sizing, setSizing, reset: resetSizing } = useColumnSizing();
+```
+
+Update `useReactTable` to include sizing config. Change the `useReactTable` call from:
+
+```ts
+const table = useReactTable({
+  data: data?.data ?? [],
+  columns: COLUMNS,
+  state: {
+    columnVisibility: visibility,
+  },
+  manualSorting: true,
+  manualPagination: true,
+  getCoreRowModel: getCoreRowModel(),
+});
+```
+
+To:
+
+```ts
+const table = useReactTable({
+  data: data?.data ?? [],
+  columns: COLUMNS,
+  columnResizeMode: "onChange",
+  state: {
+    columnVisibility: visibility,
+    columnSizing: sizing,
+  },
+  onColumnSizingChange: setSizing,
+  manualSorting: true,
+  manualPagination: true,
+  getCoreRowModel: getCoreRowModel(),
+});
+```
+
+- [ ] **Step 4: Update the Reset button to also reset sizing**
+
+Find the Reset button (around line 379):
+
+```tsx
+<button type="button" onClick={reset}>
+  Reset to defaults
+</button>
+```
+
+Change it to:
+
+```tsx
+<button
+  type="button"
+  onClick={() => {
+    reset();
+    resetSizing();
+  }}
+>
+  Reset to defaults
+</button>
+```
+
+- [ ] **Step 5: Apply width and render resize handle in the header `<th>`**
+
+Find the `<th>` for sortable columns in the header render (the one with `aria-sort`, around line 429). Change it from:
+
+```tsx
+return (
+  <th key={header.id} aria-sort={ariaSort} scope="col" aria-label={label}>
+    <button
+      type="button"
+      aria-label={`Sort by ${label}`}
+      onClick={() => sortField && handleSortClick(sortField, label)}
+    >
+      {flexRender(header.column.columnDef.header, header.getContext())}
+      {isActive && (
+        <span aria-hidden="true" className={styles.sortIndicator}>
+          {activeSortDir === "asc" ? " ▲" : " ▼"}
+        </span>
+      )}
+    </button>
+  </th>
+);
+```
+
+To:
+
+```tsx
+return (
+  <th
+    key={header.id}
+    aria-sort={ariaSort}
+    scope="col"
+    aria-label={label}
+    className={`${styles.resizableTh}${header.column.getIsResizing() ? ` ${styles.isResizing}` : ""}`}
+    style={{ width: header.getSize() }}
+  >
+    <button
+      type="button"
+      aria-label={`Sort by ${label}`}
+      onClick={() => sortField && handleSortClick(sortField, label)}
+    >
+      {flexRender(header.column.columnDef.header, header.getContext())}
+      {isActive && (
+        <span aria-hidden="true" className={styles.sortIndicator}>
+          {activeSortDir === "asc" ? " ▲" : " ▼"}
+        </span>
+      )}
+    </button>
+    {header.column.getCanResize() && (
+      <div
+        className={styles.resizeHandle}
+        onPointerDown={header.getResizeHandler()}
+        aria-hidden="true"
+        data-testid="resize-handle"
+      />
+    )}
+  </th>
+);
+```
+
+- [ ] **Step 6: Verify the app compiles with no TypeScript errors**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/SearchResults/SearchResults.tsx
+git commit -m "feat(SearchResults): wire column resizing with TanStack Table and persist to localStorage"
+```
+
+---
+
+### Task 4: SearchResults integration tests for column resizing
+
+**Files:**
+
+- Modify: `src/components/SearchResults/SearchResults.test.tsx`
+
+- [ ] **Step 1: Add the resize integration tests**
+
+Append to the end of `src/components/SearchResults/SearchResults.test.tsx`:
+
+```ts
+test("resize handle is rendered on resizable columns", async () => {
+  renderSearchResults();
+  await screen.findAllByRole("row");
+  const handles = screen.getAllByTestId("resize-handle");
+  // dayStripe has no handle; all other visible columns do
+  expect(handles.length).toBeGreaterThan(0);
+});
+
+test("dayStripe column has no resize handle", async () => {
+  renderSearchResults();
+  await screen.findAllByRole("row");
+  // dayStripe th is aria-hidden — query the DOM directly
+  const dayStripes = document.querySelectorAll("th[aria-hidden='true']");
+  dayStripes.forEach((th) => {
+    expect(th.querySelector("[data-testid='resize-handle']")).toBeNull();
+  });
+});
+
+test("pre-seeded localStorage sizing is applied to column width on mount", async () => {
+  localStorage.setItem(
+    "gcb-column-sizing",
+    JSON.stringify({ version: 1, sizing: { title: 300 } }),
+  );
+  renderSearchResults();
+  await screen.findAllByRole("row");
+  const titleTh = screen.getByRole("columnheader", { name: "Title" });
+  expect(titleTh).toHaveStyle({ width: "300px" });
+});
+
+test("Reset to defaults clears column sizing from localStorage", async () => {
+  const user = userEvent.setup();
+  localStorage.setItem(
+    "gcb-column-sizing",
+    JSON.stringify({ version: 1, sizing: { title: 300 } }),
+  );
+  renderSearchResults();
+  await screen.findAllByRole("row");
+
+  await user.click(screen.getByRole("button", { name: "Reset to defaults" }));
+
+  expect(localStorage.getItem("gcb-column-sizing")).toBeNull();
+});
+```
+
+- [ ] **Step 2: Run the new tests**
+
+```bash
+npx vitest run src/components/SearchResults/SearchResults.test.tsx
+```
+
+Expected: all tests PASS, including the 4 new ones.
+
+- [ ] **Step 3: Run the full test suite**
+
+```bash
+npx vitest run
+```
+
+Expected: all tests PASS with no regressions.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/SearchResults/SearchResults.test.tsx
+git commit -m "test(SearchResults): add column resize integration tests"
+```

--- a/docs/superpowers/specs/2026-04-20-column-actions-design.md
+++ b/docs/superpowers/specs/2026-04-20-column-actions-design.md
@@ -1,0 +1,127 @@
+# Column Actions Design
+
+**Date:** 2026-04-20  
+**Status:** Approved
+
+## Overview
+
+Add an accessible actions button to each resizable column header. The button opens a popover with sort and resize actions, providing a keyboard-accessible path alongside the existing drag-to-resize handle and click-to-sort button.
+
+## Motivation
+
+The drag-to-resize handle is mouse-only. This design adds a keyboard-accessible resize path (number input in a modal) while also consolidating sort controls into a discoverable popover.
+
+## Header Layout
+
+Each resizable `<th>` contains three controls left-to-right:
+
+1. **Sort button** (existing, unchanged) — click to cycle asc → desc → none
+2. **Actions button** — a three-vertical-dots SVG (kebab icon); opens the actions popover
+3. **Drag handle** (existing, unchanged) — absolutely positioned at the right edge
+
+The sort button takes remaining width. The actions button and drag handle are positioned at the right edge. The `<th>` already has `position: relative` from the resize implementation.
+
+## Actions Popover
+
+Built with `@base-ui/react` `Popover.Root`, consistent with the existing `Toggletip` pattern.
+
+**Trigger:** The kebab SVG button on the `<th>`.
+
+**Contents (stacked vertically):**
+
+- **Sort Ascending** — `aria-pressed` toggle button. Active when column is sorted ascending. Clicking when inactive sets sort to `field.asc`. Clicking when active clears sort.
+- **Sort Descending** — same pattern for `field.desc`. Mutually exclusive with ascending (setting one replaces the other in sort state).
+- **Resize…** — plain button that closes the popover and opens the resize dialog.
+
+**Behavior:** Closes on Escape and outside click (Base UI default).
+
+## Resize Dialog
+
+Built with `@base-ui/react` `Dialog.Root`.
+
+**Trigger:** Clicking "Resize…" in the actions popover.
+
+**Contents:**
+
+- Heading: "Resize [Column Name]"
+- `<input type="number">` labeled "Width (px)", pre-filled with `header.getSize()`
+- "Apply" button — calls `onApply(width)` with the parsed number and closes
+- "Cancel" button — closes without changes
+
+**Behavior:** Focus-trapped, closes on Escape, no custom validation (browser native number input).
+
+## Components
+
+### `ColumnActionsPopover`
+
+**Location:** `src/components/SearchResults/ColumnActionsPopover.tsx`
+
+**Props:**
+
+```ts
+interface ColumnActionsPopoverProps {
+  header: Header<Event, unknown>;
+  activeSortField: string | undefined;
+  activeSortDir: "asc" | "desc" | undefined;
+  onSort: (sort: string | undefined) => void;
+  onOpenResize: () => void;
+}
+```
+
+**Responsibility:** Renders the kebab button and Base UI Popover. Handles sort toggle logic internally (mirrors `handleSortClick` from `SearchResults`). Calls `onOpenResize` when Resize… is clicked.
+
+### `ColumnResizeDialog`
+
+**Location:** `src/components/SearchResults/ColumnResizeDialog.tsx`
+
+**Props:**
+
+```ts
+interface ColumnResizeDialogProps {
+  columnName: string;
+  currentWidth: number;
+  onApply: (width: number) => void;
+  onClose: () => void;
+}
+```
+
+**Responsibility:** Renders the Base UI Dialog. Manages local number input state initialized from `currentWidth`. Calls `onApply` with `Number(inputValue)` on Apply, calls `onClose` on Cancel or Escape.
+
+### `SearchResults` changes
+
+- Adds `resizeTarget: { columnId: string; columnName: string; currentWidth: number } | null` state.
+- Renders `<ColumnResizeDialog>` when `resizeTarget` is non-null, passing `onApply` which calls `setSizing(prev => ({ ...prev, [resizeTarget.columnId]: width }))` then clears `resizeTarget`.
+- Each resizable `<th>` renders `<ColumnActionsPopover>` alongside the existing sort button (between the sort button and the drag handle).
+
+## Testing
+
+### `ColumnActionsPopover.test.tsx`
+
+- Popover opens when kebab button is clicked
+- Sort Ascending button has `aria-pressed="false"` when column is unsorted
+- Sort Ascending button has `aria-pressed="true"` when column is sorted ascending
+- Clicking Sort Ascending (unsorted) calls `onSort("field.asc")`
+- Clicking Sort Ascending (already ascending) calls `onSort(undefined)`
+- Clicking Sort Descending (ascending active) calls `onSort("field.desc")`
+- Clicking Resize… calls `onOpenResize`
+
+### `ColumnResizeDialog.test.tsx`
+
+- Renders with heading "Resize [Column Name]"
+- Number input is pre-filled with `currentWidth`
+- Clicking Apply calls `onApply` with the input value as a number
+- Clicking Cancel calls `onClose` without calling `onApply`
+
+### `SearchResults.test.tsx` additions
+
+- Actions button is present on resizable columns
+- Actions button is absent on dayStripe column
+- Clicking Resize… on a column opens the resize dialog
+- Submitting the resize dialog updates column width in localStorage
+
+## Out of Scope
+
+- Reordering columns
+- Column pinning
+- Any changes to the drag handle behavior
+- Changes to the existing click-to-sort behavior on the sort button

--- a/docs/superpowers/specs/2026-04-20-column-resize-design.md
+++ b/docs/superpowers/specs/2026-04-20-column-resize-design.md
@@ -1,0 +1,57 @@
+# Column Resizing Design
+
+**Date:** 2026-04-20  
+**Status:** Approved
+
+## Overview
+
+Allow users to drag-resize table columns in `SearchResults`. Widths persist to `localStorage` and are reset by the existing "Reset to defaults" button.
+
+## State & Persistence
+
+A new `useColumnSizing` hook (mirroring `useColumnVisibility`) manages column width state:
+
+- Reads initial widths from `localStorage` on mount
+- Exposes `sizing` (`ColumnSizingState` — maps column IDs to pixel widths) and `reset`
+- `reset` clears stored widths and returns to TanStack defaults
+- Wired into `useReactTable` via `state.columnSizing` and `onColumnSizingChange`
+- The existing "Reset to defaults" button calls both `useColumnVisibility.reset` and `useColumnSizing.reset`
+
+localStorage key: `gcb-column-sizing` (consistent with `gcb-column-visibility` pattern).
+
+## Table Configuration
+
+- `columnResizeMode: "onChange"` — widths update live during drag
+- `dayStripe` column: `enableResizing: false`, keeps fixed 6px width
+- All other columns: resizable, widths applied via `header.getSize()` as inline `style={{ width }}`
+
+## Resize Handle
+
+Each resizable `<th>` gets `position: relative`. A resize handle `<div>` is placed as a sibling to the sort button, positioned absolutely at the right edge:
+
+- 4px wide, full cell height
+- Visible on `th:hover` with `col-resize` cursor
+- While `header.column.getIsResizing()` is true, an `isResizing` class on `<th>` keeps the handle visible
+- Calls `header.getResizeHandler()` on `pointerdown`
+- No handle rendered for `dayStripe`
+
+## Testing
+
+**`SearchResults.test.tsx`:**
+
+- Drag a resize handle → assert column width attribute changes
+- Drag a resize handle → assert new width is written to `localStorage`
+- Reset to defaults → assert `localStorage` entry is cleared and column returns to default width
+
+**`useColumnSizing.test.ts`** (co-located with the hook):
+
+- Loads initial sizing from `localStorage` on mount
+- Updates state on resize
+- `reset` clears `localStorage` and returns to empty sizing state
+
+MSW not needed — resizing is pure client state.
+
+## Out of Scope
+
+- Min/max width clamping (TanStack defaults apply)
+- Per-session-only mode (persistence is always on)

--- a/src/components/SearchResults/ColumnActionsPopover.module.css
+++ b/src/components/SearchResults/ColumnActionsPopover.module.css
@@ -1,0 +1,71 @@
+/* Absolutely positioned within the resizable <th> (which has position: relative) */
+.trigger {
+  position: absolute;
+  right: 6px; /* sits left of the 4px drag handle */
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  padding: 2px;
+  cursor: pointer;
+  color: var(--color-parchment);
+  opacity: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 2px;
+  transition: opacity var(--motion-hover);
+}
+
+/* Show on header hover or when the popover is open */
+:global(th):hover .trigger,
+.trigger:focus-visible,
+.triggerOpen {
+  opacity: 1;
+}
+
+.trigger:focus-visible {
+  outline: 2px solid var(--color-gold);
+  outline-offset: 1px;
+}
+
+.popup {
+  background: var(--color-parchment-light);
+  border: 2px solid var(--color-bark);
+  box-shadow: var(--shadow-panel);
+  display: flex;
+  flex-direction: column;
+  min-width: 148px;
+  z-index: var(--z-popover);
+}
+
+.action {
+  background: none;
+  border: none;
+  border-bottom: 1px solid var(--color-bark-light);
+  padding: var(--space-2) var(--space-3);
+  font-family: var(--font-display);
+  font-size: var(--text-label);
+  font-style: italic;
+  color: var(--color-ink);
+  cursor: pointer;
+  text-align: left;
+  width: 100%;
+}
+
+.action:last-child {
+  border-bottom: none;
+}
+
+.action:hover {
+  background: color-mix(
+    in srgb,
+    var(--color-bark-light) 20%,
+    var(--color-parchment-light)
+  );
+}
+
+.action[aria-pressed="true"] {
+  color: var(--color-bark);
+  font-weight: bold;
+}

--- a/src/components/SearchResults/ColumnActionsPopover.module.css
+++ b/src/components/SearchResults/ColumnActionsPopover.module.css
@@ -1,4 +1,3 @@
-/* Absolutely positioned within the resizable <th> (which has position: relative) */
 .trigger {
   position: absolute;
   right: 6px; /* sits left of the 4px drag handle */

--- a/src/components/SearchResults/ColumnActionsPopover.test.tsx
+++ b/src/components/SearchResults/ColumnActionsPopover.test.tsx
@@ -1,0 +1,115 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+import { ColumnActionsPopover } from "./ColumnActionsPopover";
+
+function renderPopover(
+  overrides: Partial<React.ComponentProps<typeof ColumnActionsPopover>> = {},
+) {
+  return render(
+    <ColumnActionsPopover
+      sortField="title"
+      activeSortField={undefined}
+      activeSortDir={undefined}
+      onSort={vi.fn()}
+      onOpenResize={vi.fn()}
+      {...overrides}
+    />,
+  );
+}
+
+test("renders a column actions button", () => {
+  renderPopover();
+  expect(
+    screen.getByRole("button", { name: "Column actions" }),
+  ).toBeInTheDocument();
+});
+
+test("opens popover with sort and resize actions when clicked", async () => {
+  const user = userEvent.setup();
+  renderPopover();
+  await user.click(screen.getByRole("button", { name: "Column actions" }));
+  expect(
+    screen.getByRole("button", { name: "Sort ascending" }),
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole("button", { name: "Sort descending" }),
+  ).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: "Resize…" })).toBeInTheDocument();
+});
+
+test("Sort ascending has aria-pressed=false when column is unsorted", async () => {
+  const user = userEvent.setup();
+  renderPopover({ activeSortField: undefined });
+  await user.click(screen.getByRole("button", { name: "Column actions" }));
+  expect(
+    screen.getByRole("button", { name: "Sort ascending" }),
+  ).toHaveAttribute("aria-pressed", "false");
+});
+
+test("Sort ascending has aria-pressed=true when column is sorted ascending", async () => {
+  const user = userEvent.setup();
+  renderPopover({ activeSortField: "title", activeSortDir: "asc" });
+  await user.click(screen.getByRole("button", { name: "Column actions" }));
+  expect(
+    screen.getByRole("button", { name: "Sort ascending" }),
+  ).toHaveAttribute("aria-pressed", "true");
+});
+
+test("Sort descending has aria-pressed=true when column is sorted descending", async () => {
+  const user = userEvent.setup();
+  renderPopover({ activeSortField: "title", activeSortDir: "desc" });
+  await user.click(screen.getByRole("button", { name: "Column actions" }));
+  expect(
+    screen.getByRole("button", { name: "Sort descending" }),
+  ).toHaveAttribute("aria-pressed", "true");
+});
+
+test("clicking Sort ascending when unsorted calls onSort with field.asc", async () => {
+  const user = userEvent.setup();
+  const onSort = vi.fn();
+  renderPopover({ onSort });
+  await user.click(screen.getByRole("button", { name: "Column actions" }));
+  await user.click(screen.getByRole("button", { name: "Sort ascending" }));
+  expect(onSort).toHaveBeenCalledWith("title.asc");
+});
+
+test("clicking Sort ascending when already ascending calls onSort with undefined", async () => {
+  const user = userEvent.setup();
+  const onSort = vi.fn();
+  renderPopover({ activeSortField: "title", activeSortDir: "asc", onSort });
+  await user.click(screen.getByRole("button", { name: "Column actions" }));
+  await user.click(screen.getByRole("button", { name: "Sort ascending" }));
+  expect(onSort).toHaveBeenCalledWith(undefined);
+});
+
+test("clicking Sort descending when ascending calls onSort with field.desc", async () => {
+  const user = userEvent.setup();
+  const onSort = vi.fn();
+  renderPopover({ activeSortField: "title", activeSortDir: "asc", onSort });
+  await user.click(screen.getByRole("button", { name: "Column actions" }));
+  await user.click(screen.getByRole("button", { name: "Sort descending" }));
+  expect(onSort).toHaveBeenCalledWith("title.desc");
+});
+
+test("clicking Resize… calls onOpenResize", async () => {
+  const user = userEvent.setup();
+  const onOpenResize = vi.fn();
+  renderPopover({ onOpenResize });
+  await user.click(screen.getByRole("button", { name: "Column actions" }));
+  await user.click(screen.getByRole("button", { name: "Resize…" }));
+  expect(onOpenResize).toHaveBeenCalledTimes(1);
+});
+
+test("does not render sort buttons when sortField is undefined", async () => {
+  const user = userEvent.setup();
+  renderPopover({ sortField: undefined });
+  await user.click(screen.getByRole("button", { name: "Column actions" }));
+  expect(
+    screen.queryByRole("button", { name: "Sort ascending" }),
+  ).not.toBeInTheDocument();
+  expect(
+    screen.queryByRole("button", { name: "Sort descending" }),
+  ).not.toBeInTheDocument();
+  expect(screen.getByRole("button", { name: "Resize…" })).toBeInTheDocument();
+});

--- a/src/components/SearchResults/ColumnActionsPopover.tsx
+++ b/src/components/SearchResults/ColumnActionsPopover.tsx
@@ -1,0 +1,89 @@
+import { useState } from "react";
+import { Popover } from "@base-ui/react/popover";
+import styles from "./ColumnActionsPopover.module.css";
+
+interface ColumnActionsPopoverProps {
+  sortField: string | undefined;
+  activeSortField: string | undefined;
+  activeSortDir: "asc" | "desc" | undefined;
+  onSort: (sort: string | undefined) => void;
+  onOpenResize: () => void;
+}
+
+export function ColumnActionsPopover({
+  sortField,
+  activeSortField,
+  activeSortDir,
+  onSort,
+  onOpenResize,
+}: ColumnActionsPopoverProps) {
+  const [open, setOpen] = useState(false);
+
+  const isSortedAsc =
+    !!sortField && activeSortField === sortField && activeSortDir === "asc";
+  const isSortedDesc =
+    !!sortField && activeSortField === sortField && activeSortDir === "desc";
+
+  return (
+    <Popover.Root open={open} onOpenChange={setOpen}>
+      <Popover.Trigger
+        className={`${styles.trigger}${open ? ` ${styles.triggerOpen}` : ""}`}
+        aria-label="Column actions"
+      >
+        <svg
+          width="12"
+          height="12"
+          viewBox="0 0 12 12"
+          aria-hidden="true"
+          focusable="false"
+        >
+          <circle cx="6" cy="2" r="1.5" fill="currentColor" />
+          <circle cx="6" cy="6" r="1.5" fill="currentColor" />
+          <circle cx="6" cy="10" r="1.5" fill="currentColor" />
+        </svg>
+      </Popover.Trigger>
+      <Popover.Portal>
+        <Popover.Positioner sideOffset={4}>
+          <Popover.Popup className={styles.popup}>
+            {sortField && (
+              <>
+                <button
+                  type="button"
+                  className={styles.action}
+                  aria-pressed={isSortedAsc}
+                  onClick={() => {
+                    onSort(isSortedAsc ? undefined : `${sortField}.asc`);
+                    setOpen(false);
+                  }}
+                >
+                  Sort ascending
+                </button>
+                <button
+                  type="button"
+                  className={styles.action}
+                  aria-pressed={isSortedDesc}
+                  onClick={() => {
+                    onSort(isSortedDesc ? undefined : `${sortField}.desc`);
+                    setOpen(false);
+                  }}
+                >
+                  Sort descending
+                </button>
+              </>
+            )}
+            <button
+              type="button"
+              className={styles.action}
+              onClick={() => {
+                setOpen(false);
+                onOpenResize();
+              }}
+            >
+              Resize…
+            </button>
+          </Popover.Popup>
+        </Popover.Positioner>
+      </Popover.Portal>
+    </Popover.Root>
+  );
+}

--- a/src/components/SearchResults/ColumnResizeDialog.module.css
+++ b/src/components/SearchResults/ColumnResizeDialog.module.css
@@ -1,0 +1,87 @@
+.backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(59, 30, 10, 0.35);
+  z-index: calc(var(--z-modal) - 1);
+}
+
+.popup {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: var(--color-parchment-light);
+  border: 2px solid var(--color-bark);
+  box-shadow: var(--shadow-panel);
+  padding: var(--space-4);
+  min-width: 260px;
+  z-index: var(--z-modal);
+}
+
+.title {
+  font-family: var(--font-display);
+  font-size: var(--text-heading);
+  font-style: italic;
+  color: var(--color-bark);
+  margin: 0 0 var(--space-3);
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  margin-bottom: var(--space-4);
+}
+
+.label {
+  font-family: var(--font-display);
+  font-size: var(--text-label);
+  font-style: italic;
+  color: var(--color-ink);
+}
+
+.input {
+  font-family: var(--font-data);
+  font-size: var(--text-small);
+  border: 2px solid var(--color-bark);
+  padding: var(--space-1) var(--space-2);
+  background: var(--color-parchment);
+  color: var(--color-ink);
+  width: 100%;
+}
+
+.input:focus {
+  outline: 2px solid var(--color-gold);
+  outline-offset: 1px;
+}
+
+.actions {
+  display: flex;
+  gap: var(--space-2);
+  justify-content: flex-end;
+}
+
+.button {
+  font-family: var(--font-display);
+  font-size: var(--text-label);
+  font-style: italic;
+  background: var(--color-parchment);
+  border: 2px solid var(--color-bark);
+  color: var(--color-bark);
+  padding: var(--space-1) var(--space-3);
+  cursor: pointer;
+}
+
+.button:hover {
+  background: var(--color-bark-light);
+  color: var(--color-parchment-light);
+}
+
+.primaryButton {
+  background: var(--color-bark);
+  color: var(--color-parchment-light);
+}
+
+.primaryButton:hover {
+  background: var(--color-bark-dark);
+}

--- a/src/components/SearchResults/ColumnResizeDialog.test.tsx
+++ b/src/components/SearchResults/ColumnResizeDialog.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+import { ColumnResizeDialog } from "./ColumnResizeDialog";
+
+test("renders with the column name in the heading", () => {
+  render(
+    <ColumnResizeDialog
+      columnName="Title"
+      currentWidth={150}
+      onApply={vi.fn()}
+      onClose={vi.fn()}
+    />,
+  );
+  expect(
+    screen.getByRole("heading", { name: "Resize Title" }),
+  ).toBeInTheDocument();
+});
+
+test("pre-fills the number input with currentWidth", () => {
+  render(
+    <ColumnResizeDialog
+      columnName="Title"
+      currentWidth={200}
+      onApply={vi.fn()}
+      onClose={vi.fn()}
+    />,
+  );
+  expect(screen.getByRole("spinbutton", { name: "Width (px)" })).toHaveValue(
+    200,
+  );
+});
+
+test("clicking Apply calls onApply with the parsed number value", async () => {
+  const user = userEvent.setup();
+  const onApply = vi.fn();
+  render(
+    <ColumnResizeDialog
+      columnName="Title"
+      currentWidth={150}
+      onApply={onApply}
+      onClose={vi.fn()}
+    />,
+  );
+  const input = screen.getByRole("spinbutton", { name: "Width (px)" });
+  await user.clear(input);
+  await user.type(input, "300");
+  await user.click(screen.getByRole("button", { name: "Apply" }));
+  expect(onApply).toHaveBeenCalledWith(300);
+});
+
+test("clicking Cancel calls onClose without calling onApply", async () => {
+  const user = userEvent.setup();
+  const onApply = vi.fn();
+  const onClose = vi.fn();
+  render(
+    <ColumnResizeDialog
+      columnName="Title"
+      currentWidth={150}
+      onApply={onApply}
+      onClose={onClose}
+    />,
+  );
+  await user.click(screen.getByRole("button", { name: "Cancel" }));
+  expect(onClose).toHaveBeenCalledTimes(1);
+  expect(onApply).not.toHaveBeenCalled();
+});

--- a/src/components/SearchResults/ColumnResizeDialog.tsx
+++ b/src/components/SearchResults/ColumnResizeDialog.tsx
@@ -1,0 +1,61 @@
+import { useState } from "react";
+import { Dialog } from "@base-ui/react/dialog";
+import styles from "./ColumnResizeDialog.module.css";
+
+interface ColumnResizeDialogProps {
+  columnName: string;
+  currentWidth: number;
+  onApply: (width: number) => void;
+  onClose: () => void;
+}
+
+export function ColumnResizeDialog({
+  columnName,
+  currentWidth,
+  onApply,
+  onClose,
+}: ColumnResizeDialogProps) {
+  const [value, setValue] = useState(String(currentWidth));
+
+  return (
+    <Dialog.Root
+      open={true}
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <Dialog.Portal>
+        <Dialog.Backdrop className={styles.backdrop} />
+        <Dialog.Popup className={styles.popup}>
+          <Dialog.Title className={styles.title}>
+            Resize {columnName}
+          </Dialog.Title>
+          <div className={styles.field}>
+            <label htmlFor="resize-width-input" className={styles.label}>
+              Width (px)
+            </label>
+            <input
+              id="resize-width-input"
+              type="number"
+              className={styles.input}
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+            />
+          </div>
+          <div className={styles.actions}>
+            <button type="button" className={styles.button} onClick={onClose}>
+              Cancel
+            </button>
+            <button
+              type="button"
+              className={`${styles.button} ${styles.primaryButton}`}
+              onClick={() => onApply(Number(value))}
+            >
+              Apply
+            </button>
+          </div>
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/src/components/SearchResults/ColumnResizeDialog.tsx
+++ b/src/components/SearchResults/ColumnResizeDialog.tsx
@@ -49,7 +49,10 @@ export function ColumnResizeDialog({
             <button
               type="button"
               className={`${styles.button} ${styles.primaryButton}`}
-              onClick={() => onApply(Number(value))}
+              onClick={() => {
+                onApply(Number(value));
+                onClose();
+              }}
             >
               Apply
             </button>

--- a/src/components/SearchResults/ColumnResizeDialog.tsx
+++ b/src/components/SearchResults/ColumnResizeDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useId } from "react";
 import { Dialog } from "@base-ui/react/dialog";
 import styles from "./ColumnResizeDialog.module.css";
 
@@ -16,6 +16,7 @@ export function ColumnResizeDialog({
   onClose,
 }: ColumnResizeDialogProps) {
   const [value, setValue] = useState(String(currentWidth));
+  const inputId = useId();
 
   return (
     <Dialog.Root
@@ -31,11 +32,11 @@ export function ColumnResizeDialog({
             Resize {columnName}
           </Dialog.Title>
           <div className={styles.field}>
-            <label htmlFor="resize-width-input" className={styles.label}>
+            <label htmlFor={inputId} className={styles.label}>
               Width (px)
             </label>
             <input
-              id="resize-width-input"
+              id={inputId}
               type="number"
               className={styles.input}
               value={value}

--- a/src/components/SearchResults/SearchResults.module.css
+++ b/src/components/SearchResults/SearchResults.module.css
@@ -138,6 +138,7 @@
 /* Column resize handle */
 .resizableTh {
   position: relative;
+  padding-right: 26px;
 }
 
 .resizeHandle {

--- a/src/components/SearchResults/SearchResults.module.css
+++ b/src/components/SearchResults/SearchResults.module.css
@@ -11,6 +11,7 @@
 .tableWrapper table {
   width: 100%;
   border-collapse: collapse;
+  table-layout: fixed;
   font-family: var(--font-data);
 }
 
@@ -153,7 +154,7 @@
 }
 
 .resizableTh:hover .resizeHandle,
-.isResizing .resizeHandle {
+.resizableTh.isResizing .resizeHandle {
   opacity: 1;
   background: var(--color-gold);
 }

--- a/src/components/SearchResults/SearchResults.module.css
+++ b/src/components/SearchResults/SearchResults.module.css
@@ -133,3 +133,27 @@
     transform: scale(1);
   }
 }
+
+/* Column resize handle */
+.resizableTh {
+  position: relative;
+}
+
+.resizeHandle {
+  position: absolute;
+  right: 0;
+  top: 0;
+  height: 100%;
+  width: 4px;
+  cursor: col-resize;
+  background: transparent;
+  opacity: 0;
+  transition: opacity 100ms;
+  user-select: none;
+}
+
+.resizableTh:hover .resizeHandle,
+.isResizing .resizeHandle {
+  opacity: 1;
+  background: var(--color-gold);
+}

--- a/src/components/SearchResults/SearchResults.test.tsx
+++ b/src/components/SearchResults/SearchResults.test.tsx
@@ -461,3 +461,46 @@ test('announces "Sort cleared" when clicking descending column', async () => {
   });
   cleanup();
 });
+
+test("resize handle is rendered on resizable columns", async () => {
+  renderSearchResults();
+  await screen.findAllByRole("row");
+  const handles = screen.getAllByTestId("resize-handle");
+  // dayStripe has no handle; all other visible columns do
+  expect(handles.length).toBeGreaterThan(0);
+});
+
+test("dayStripe column has no resize handle", async () => {
+  renderSearchResults();
+  await screen.findAllByRole("row");
+  // dayStripe th is aria-hidden — query the DOM directly
+  const dayStripes = document.querySelectorAll("th[aria-hidden='true']");
+  dayStripes.forEach((th) => {
+    expect(th.querySelector("[data-testid='resize-handle']")).toBeNull();
+  });
+});
+
+test("pre-seeded localStorage sizing is applied to column width on mount", async () => {
+  localStorage.setItem(
+    "gcb-column-sizing",
+    JSON.stringify({ version: 1, sizing: { title: 300 } }),
+  );
+  renderSearchResults();
+  await screen.findAllByRole("row");
+  const titleTh = screen.getByRole("columnheader", { name: "Title" });
+  expect(titleTh).toHaveStyle({ width: "300px" });
+});
+
+test("Reset to defaults clears column sizing from localStorage", async () => {
+  const user = userEvent.setup();
+  localStorage.setItem(
+    "gcb-column-sizing",
+    JSON.stringify({ version: 1, sizing: { title: 300 } }),
+  );
+  renderSearchResults();
+  await screen.findAllByRole("row");
+
+  await user.click(screen.getByRole("button", { name: "Reset to defaults" }));
+
+  expect(localStorage.getItem("gcb-column-sizing")).toBeNull();
+});

--- a/src/components/SearchResults/SearchResults.test.tsx
+++ b/src/components/SearchResults/SearchResults.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { vi } from "vitest";
 import {
@@ -503,4 +503,51 @@ test("Reset to defaults clears column sizing from localStorage", async () => {
   await user.click(screen.getByRole("button", { name: "Reset to defaults" }));
 
   expect(localStorage.getItem("gcb-column-sizing")).toBeNull();
+});
+
+test("actions button is present on resizable columns", async () => {
+  renderSearchResults();
+  await screen.findAllByRole("row");
+  const actionButtons = screen.getAllByRole("button", {
+    name: "Column actions",
+  });
+  expect(actionButtons.length).toBeGreaterThan(0);
+});
+
+test("actions button is absent on dayStripe column", async () => {
+  renderSearchResults();
+  await screen.findAllByRole("row");
+  const dayStripes = document.querySelectorAll("th[aria-hidden='true']");
+  dayStripes.forEach((th) => {
+    expect(th.querySelector("[aria-label='Column actions']")).toBeNull();
+  });
+});
+
+test("clicking Resize… on a column opens the resize dialog", async () => {
+  const user = userEvent.setup();
+  renderSearchResults();
+  await screen.findAllByRole("row");
+  const titleTh = screen.getByRole("columnheader", { name: "Title" });
+  await user.click(
+    within(titleTh).getByRole("button", { name: "Column actions" }),
+  );
+  await user.click(screen.getByRole("button", { name: "Resize…" }));
+  expect(screen.getByRole("dialog")).toBeInTheDocument();
+});
+
+test("submitting resize dialog updates column width in localStorage", async () => {
+  const user = userEvent.setup();
+  renderSearchResults();
+  await screen.findAllByRole("row");
+  const titleTh = screen.getByRole("columnheader", { name: "Title" });
+  await user.click(
+    within(titleTh).getByRole("button", { name: "Column actions" }),
+  );
+  await user.click(screen.getByRole("button", { name: "Resize…" }));
+  const input = screen.getByRole("spinbutton", { name: "Width (px)" });
+  await user.clear(input);
+  await user.type(input, "400");
+  await user.click(screen.getByRole("button", { name: "Apply" }));
+  const stored = JSON.parse(localStorage.getItem("gcb-column-sizing")!);
+  expect(stored).toEqual({ version: 1, sizing: { title: 400 } });
 });

--- a/src/components/SearchResults/SearchResults.tsx
+++ b/src/components/SearchResults/SearchResults.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import {
   useReactTable,
   getCoreRowModel,
@@ -9,6 +10,8 @@ import { Link } from "@tanstack/react-router";
 import { format } from "date-fns";
 import { useColumnVisibility } from "../../hooks/useColumnVisibility";
 import { useColumnSizing } from "../../hooks/useColumnSizing";
+import { ColumnActionsPopover } from "./ColumnActionsPopover";
+import { ColumnResizeDialog } from "./ColumnResizeDialog";
 import { fetchEvents } from "../../utils/api";
 import { Pagination } from "../Pagination/Pagination";
 import { announce } from "../../lib/announce";
@@ -309,6 +312,11 @@ export function SearchResults({
 }: SearchResultsProps) {
   const { visibility, toggle, reset } = useColumnVisibility();
   const { sizing, setSizing, reset: resetSizing } = useColumnSizing();
+  const [resizeTarget, setResizeTarget] = useState<{
+    columnId: string;
+    columnName: string;
+    currentWidth: number;
+  } | null>(null);
   const page = searchParams.page ?? 1;
   const limit = searchParams.limit ?? 100;
   const { data, isLoading, isError } = useQuery({
@@ -467,6 +475,21 @@ export function SearchResults({
                             )}
                           </button>
                           {header.column.getCanResize() && (
+                            <ColumnActionsPopover
+                              sortField={sortField}
+                              activeSortField={activeSortField}
+                              activeSortDir={activeSortDir}
+                              onSort={onSort}
+                              onOpenResize={() =>
+                                setResizeTarget({
+                                  columnId: header.column.id,
+                                  columnName: label,
+                                  currentWidth: header.getSize(),
+                                })
+                              }
+                            />
+                          )}
+                          {header.column.getCanResize() && (
                             <div
                               className={styles.resizeHandle}
                               onPointerDown={header.getResizeHandler()}
@@ -522,6 +545,20 @@ export function SearchResults({
           </div>
           {pagination}
         </>
+      )}
+      {resizeTarget && (
+        <ColumnResizeDialog
+          columnName={resizeTarget.columnName}
+          currentWidth={resizeTarget.currentWidth}
+          onApply={(width) => {
+            setSizing((prev) => ({
+              ...prev,
+              [resizeTarget.columnId]: width,
+            }));
+            setResizeTarget(null);
+          }}
+          onClose={() => setResizeTarget(null)}
+        />
       )}
     </section>
   );

--- a/src/components/SearchResults/SearchResults.tsx
+++ b/src/components/SearchResults/SearchResults.tsx
@@ -371,6 +371,10 @@ export function SearchResults({
       />
     ) : null;
 
+  const resizeColumnId = resizeTarget?.columnId;
+  const resizeColumnName = resizeTarget?.columnName;
+  const resizeCurrentWidth = resizeTarget?.currentWidth;
+
   return (
     <section>
       <details className={styles.visibilityPanel}>
@@ -546,25 +550,19 @@ export function SearchResults({
           {pagination}
         </>
       )}
-      {resizeTarget &&
-        (() => {
-          const resizeColumnId = resizeTarget.columnId;
-          return (
-            <ColumnResizeDialog
-              columnName={resizeTarget.columnName}
-              currentWidth={resizeTarget.currentWidth}
-              onApply={(width) => {
-                if (resizeColumnId) {
-                  setSizing((prev) => ({
-                    ...prev,
-                    [resizeColumnId]: width,
-                  }));
-                }
-              }}
-              onClose={() => setResizeTarget(null)}
-            />
-          );
-        })()}
+      {resizeTarget && (
+        <ColumnResizeDialog
+          columnName={resizeColumnName!}
+          currentWidth={resizeCurrentWidth!}
+          onApply={(width) => {
+            setSizing((prev) => ({
+              ...prev,
+              [resizeColumnId!]: width,
+            }));
+          }}
+          onClose={() => setResizeTarget(null)}
+        />
+      )}
     </section>
   );
 }

--- a/src/components/SearchResults/SearchResults.tsx
+++ b/src/components/SearchResults/SearchResults.tsx
@@ -8,6 +8,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { format } from "date-fns";
 import { useColumnVisibility } from "../../hooks/useColumnVisibility";
+import { useColumnSizing } from "../../hooks/useColumnSizing";
 import { fetchEvents } from "../../utils/api";
 import { Pagination } from "../Pagination/Pagination";
 import { announce } from "../../lib/announce";
@@ -37,6 +38,7 @@ const COLUMNS: ColumnDef<Event>[] = [
     id: "dayStripe",
     header: () => null,
     cell: () => null, // rendered specially in the row loop
+    enableResizing: false,
   },
   {
     id: "gameId",
@@ -306,6 +308,7 @@ export function SearchResults({
   onSort,
 }: SearchResultsProps) {
   const { visibility, toggle, reset } = useColumnVisibility();
+  const { sizing, setSizing, reset: resetSizing } = useColumnSizing();
   const page = searchParams.page ?? 1;
   const limit = searchParams.limit ?? 100;
   const { data, isLoading, isError } = useQuery({
@@ -339,9 +342,12 @@ export function SearchResults({
   const table = useReactTable({
     data: data?.data ?? [],
     columns: COLUMNS,
+    columnResizeMode: "onChange",
     state: {
       columnVisibility: visibility,
+      columnSizing: sizing,
     },
+    onColumnSizingChange: setSizing,
     manualSorting: true,
     manualPagination: true,
     getCoreRowModel: getCoreRowModel(),
@@ -376,7 +382,13 @@ export function SearchResults({
               </li>
             ))}
           </ul>
-          <button type="button" onClick={reset}>
+          <button
+            type="button"
+            onClick={() => {
+              reset();
+              resetSizing();
+            }}
+          >
             Reset to defaults
           </button>
         </fieldset>
@@ -431,6 +443,8 @@ export function SearchResults({
                           aria-sort={ariaSort}
                           scope="col"
                           aria-label={label}
+                          className={`${styles.resizableTh}${header.column.getIsResizing() ? ` ${styles.isResizing}` : ""}`}
+                          style={{ width: header.getSize() }}
                         >
                           <button
                             type="button"
@@ -452,6 +466,14 @@ export function SearchResults({
                               </span>
                             )}
                           </button>
+                          {header.column.getCanResize() && (
+                            <div
+                              className={styles.resizeHandle}
+                              onPointerDown={header.getResizeHandler()}
+                              aria-hidden="true"
+                              data-testid="resize-handle"
+                            />
+                          )}
                         </th>
                       );
                     })}

--- a/src/components/SearchResults/SearchResults.tsx
+++ b/src/components/SearchResults/SearchResults.tsx
@@ -546,20 +546,25 @@ export function SearchResults({
           {pagination}
         </>
       )}
-      {resizeTarget && (
-        <ColumnResizeDialog
-          columnName={resizeTarget.columnName}
-          currentWidth={resizeTarget.currentWidth}
-          onApply={(width) => {
-            setSizing((prev) => ({
-              ...prev,
-              [resizeTarget.columnId]: width,
-            }));
-            setResizeTarget(null);
-          }}
-          onClose={() => setResizeTarget(null)}
-        />
-      )}
+      {resizeTarget &&
+        (() => {
+          const resizeColumnId = resizeTarget.columnId;
+          return (
+            <ColumnResizeDialog
+              columnName={resizeTarget.columnName}
+              currentWidth={resizeTarget.currentWidth}
+              onApply={(width) => {
+                if (resizeColumnId) {
+                  setSizing((prev) => ({
+                    ...prev,
+                    [resizeColumnId]: width,
+                  }));
+                }
+              }}
+              onClose={() => setResizeTarget(null)}
+            />
+          );
+        })()}
     </section>
   );
 }

--- a/src/hooks/useColumnSizing.test.ts
+++ b/src/hooks/useColumnSizing.test.ts
@@ -1,0 +1,91 @@
+import { renderHook, act } from "@testing-library/react";
+import { useColumnSizing } from "./useColumnSizing";
+
+const STORAGE_KEY = "gcb-column-sizing";
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+test("returns empty sizing on first use", () => {
+  const { result } = renderHook(() => useColumnSizing());
+  expect(result.current.sizing).toEqual({});
+});
+
+test("setSizing with a value updates state", () => {
+  const { result } = renderHook(() => useColumnSizing());
+
+  act(() => {
+    result.current.setSizing({ title: 300 });
+  });
+
+  expect(result.current.sizing).toEqual({ title: 300 });
+});
+
+test("setSizing with an updater function updates state", () => {
+  const { result } = renderHook(() => useColumnSizing());
+
+  act(() => {
+    result.current.setSizing({ title: 200 });
+  });
+  act(() => {
+    result.current.setSizing((prev) => ({ ...prev, gameId: 100 }));
+  });
+
+  expect(result.current.sizing).toEqual({ title: 200, gameId: 100 });
+});
+
+test("persists sizing to localStorage", () => {
+  const { result } = renderHook(() => useColumnSizing());
+
+  act(() => {
+    result.current.setSizing({ title: 300 });
+  });
+
+  const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+  expect(stored).toEqual({ version: 1, sizing: { title: 300 } });
+});
+
+test("loads sizing from localStorage on mount", () => {
+  localStorage.setItem(
+    STORAGE_KEY,
+    JSON.stringify({ version: 1, sizing: { title: 300, gameId: 150 } }),
+  );
+
+  const { result } = renderHook(() => useColumnSizing());
+  expect(result.current.sizing).toEqual({ title: 300, gameId: 150 });
+});
+
+test("returns empty sizing when stored version does not match", () => {
+  localStorage.setItem(
+    STORAGE_KEY,
+    JSON.stringify({ version: 9999, sizing: { title: 300 } }),
+  );
+
+  const { result } = renderHook(() => useColumnSizing());
+  expect(result.current.sizing).toEqual({});
+});
+
+test("returns empty sizing when localStorage is malformed", () => {
+  localStorage.setItem(STORAGE_KEY, "not-json{{{");
+
+  const { result } = renderHook(() => useColumnSizing());
+  expect(result.current.sizing).toEqual({});
+});
+
+test("reset clears sizing state and removes localStorage key", () => {
+  const { result } = renderHook(() => useColumnSizing());
+
+  act(() => {
+    result.current.setSizing({ title: 300 });
+  });
+
+  expect(result.current.sizing).toEqual({ title: 300 });
+
+  act(() => {
+    result.current.reset();
+  });
+
+  expect(result.current.sizing).toEqual({});
+  expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+});

--- a/src/hooks/useColumnSizing.ts
+++ b/src/hooks/useColumnSizing.ts
@@ -1,0 +1,52 @@
+import { useState, useEffect } from "react";
+import type { ColumnSizingState, OnChangeFn } from "@tanstack/react-table";
+
+const STORAGE_KEY = "gcb-column-sizing";
+const VERSION = 1;
+
+function readFromStorage(): ColumnSizingState {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      (parsed as { version?: unknown }).version !== VERSION
+    ) {
+      return {};
+    }
+    return (parsed as { version: number; sizing: ColumnSizingState }).sizing;
+  } catch {
+    return {};
+  }
+}
+
+export function useColumnSizing() {
+  const [sizing, setSizingState] = useState<ColumnSizingState>(readFromStorage);
+
+  useEffect(() => {
+    if (Object.keys(sizing).length === 0) {
+      localStorage.removeItem(STORAGE_KEY);
+    } else {
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({ version: VERSION, sizing }),
+      );
+    }
+  }, [sizing]);
+
+  const setSizing: OnChangeFn<ColumnSizingState> = (updaterOrValue) => {
+    setSizingState((prev) =>
+      typeof updaterOrValue === "function"
+        ? updaterOrValue(prev)
+        : updaterOrValue,
+    );
+  };
+
+  const reset = () => {
+    setSizingState({});
+  };
+
+  return { sizing, setSizing, reset };
+}


### PR DESCRIPTION
## Summary

- Adds a kebab (three-dot) actions button to each resizable column header, providing a keyboard-accessible path alongside the existing drag-to-resize handle
- Clicking the button opens a popover (Base UI) with Sort Ascending, Sort Descending (both `aria-pressed` toggles, mutually exclusive), and Resize… actions
- Resize… opens a modal dialog (Base UI) where the user can type a pixel value; Apply persists the new width to localStorage via the existing `useColumnSizing` hook

## Test Plan

- [ ] Click the kebab button on a column header — popover appears with sort and resize actions
- [ ] Click Sort Ascending — column sorts ascending, button shows `aria-pressed=true`; clicking again clears sort
- [ ] Click Sort Descending while ascending is active — sort switches to descending (mutually exclusive)
- [ ] Click Resize… — dialog opens pre-filled with current column width
- [ ] Type a new width and click Apply — column resizes, value persists on page reload
- [ ] Click Cancel in dialog — no change
- [ ] Tab to the kebab button and activate with Enter/Space — popover opens (keyboard accessible)
- [ ] dayStripe column has no kebab button
- [ ] 268 tests passing: `npx vitest run`