### PR TITLE
deps(wave-4): bump react 18→19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,8 @@
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
         "lucide-react": "^1.14.0",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1",
+        "react": "^19.2.5",
+        "react-dom": "^19.2.5",
         "react-hook-form": "^7.55.0"
       },
       "devDependencies": {
@@ -25,8 +25,8 @@
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.0",
-        "@types/react": "^18.3.1",
-        "@types/react-dom": "^18.3.1",
+        "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.3",
         "@typescript-eslint/parser": "^8.58.2",
         "@vitejs/plugin-react": "^6.0.1",
         "concurrently": "^9.2.1",
@@ -3313,32 +3313,24 @@
         "undici-types": "~7.19.0"
       }
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.15",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
-      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "devOptional": true,
-      "license": "MIT"
-    },
     "node_modules/@types/react": {
-      "version": "18.3.28",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
-      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@types/prop-types": "*",
         "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.3.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@types/react": "^18.0.0"
+        "@types/react": "^19.2.0"
       }
     },
     "node_modules/@types/resolve": {
@@ -5675,6 +5667,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -6119,18 +6112,6 @@
       "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
     },
     "node_modules/loupe": {
       "version": "3.2.1",
@@ -6898,13 +6879,10 @@
       "license": "MIT"
     },
     "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6942,16 +6920,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^18.3.1"
+        "react": "^19.2.5"
       }
     },
     "node_modules/react-hook-form": {
@@ -7226,13 +7203,10 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "6.3.1",

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "lucide-react": "^1.14.0",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5",
     "react-hook-form": "^7.55.0"
   },
   "devDependencies": {
@@ -38,8 +38,8 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.0",
-    "@types/react": "^18.3.1",
-    "@types/react-dom": "^18.3.1",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
     "@typescript-eslint/parser": "^8.58.2",
     "@vitejs/plugin-react": "^6.0.1",
     "concurrently": "^9.2.1",

--- a/src/components/AboutPage/AboutPage.tsx
+++ b/src/components/AboutPage/AboutPage.tsx
@@ -1,6 +1,7 @@
+import React from "react";
 import styles from "./AboutPage.module.css";
 
-export function AboutPage(): JSX.Element {
+export function AboutPage(): React.JSX.Element {
   return (
     <main className={styles.page}>
       <div className={styles.content}>

--- a/src/components/ChangelogPage/ChangelogEntryPanel.tsx
+++ b/src/components/ChangelogPage/ChangelogEntryPanel.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { AnimatedDetails } from "../../ui/AnimatedDetails/AnimatedDetails";
 import { EmptyState } from "../../ui/EmptyState/EmptyState";
 import { EventListMobile } from "../../ui/EventTable/EventListMobile";
@@ -19,7 +20,7 @@ function EventGroup({
 }: {
   events: Event[];
   sharedColumnState: SharedColumnState;
-}): JSX.Element {
+}): React.JSX.Element {
   return (
     <>
       <div className={styles.tableView}>
@@ -43,7 +44,7 @@ function EventGroup({
 export function ChangelogEntryPanel({
   entry,
   sharedColumnState,
-}: ChangelogEntryPanelProps): JSX.Element {
+}: ChangelogEntryPanelProps): React.JSX.Element {
   if (entry === undefined || entry === "loading") {
     return <p aria-busy="true">Loading…</p>;
   }

--- a/src/components/ChangelogPage/ChangelogPage.tsx
+++ b/src/components/ChangelogPage/ChangelogPage.tsx
@@ -1,5 +1,5 @@
+import React, { useEffect } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect } from "react";
 import { useColumnSizing } from "../../hooks/useColumnSizing";
 import { useColumnVisibility } from "../../hooks/useColumnVisibility";
 import { useTypeDisplay } from "../../hooks/useTypeDisplay";
@@ -9,7 +9,7 @@ import { fetchChangelogEntry, fetchChangelogList } from "../../utils/api";
 import styles from "./ChangelogPage.module.css";
 import { ChangelogRow } from "./ChangelogRow";
 
-export function ChangelogPage(): JSX.Element {
+export function ChangelogPage(): React.JSX.Element {
   const queryClient = useQueryClient();
   const { visibility, toggle: toggleVisibility, reset: resetVisibility } = useColumnVisibility();
   const { sizing, setSizing, reset: resetSizing } = useColumnSizing();

--- a/src/components/ChangelogPage/ChangelogRow.tsx
+++ b/src/components/ChangelogPage/ChangelogRow.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import React, { useState } from "react";
 import { format } from "date-fns";
 import { useQuery } from "@tanstack/react-query";
 import type { ChangelogSummary } from "../../utils/types";
@@ -18,7 +18,7 @@ export function ChangelogRow({
   summary,
   onOpen,
   sharedColumnState,
-}: ChangelogRowProps): JSX.Element {
+}: ChangelogRowProps): React.JSX.Element {
   const [isOpen, setIsOpen] = useState(false);
   const { data: entry, isError } = useQuery({
     queryKey: ["changelog", "entry", summary.id],

--- a/src/components/EventDetail/EventDetail.tsx
+++ b/src/components/EventDetail/EventDetail.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { useQuery } from "@tanstack/react-query";
 import { format } from "date-fns";
 import { Link } from "@tanstack/react-router";
@@ -14,7 +15,7 @@ interface EventDetailProps {
   gameId: string;
 }
 
-export function EventDetail({ gameId }: EventDetailProps): JSX.Element {
+export function EventDetail({ gameId }: EventDetailProps): React.JSX.Element {
   const { data, isLoading, isError } = useQuery({
     queryKey: ["event", gameId],
     queryFn: () => fetchEvents({ gameId, limit: 1 }),

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { Button } from "../../ui/Button/Button";
 import { Select } from "../../ui/Select/Select";
@@ -41,7 +42,7 @@ export function Pagination({
   onNavigate,
   "aria-label": ariaLabel = "Pagination",
   singleLine = false,
-}: PaginationProps): JSX.Element {
+}: PaginationProps): React.JSX.Element {
   const naturalTotalPages = Math.ceil(total / limit);
   const maxPages = Math.floor(BACKEND_MAX_RESULTS / limit);
   const totalPages = Math.min(naturalTotalPages, maxPages);

--- a/src/components/SearchForm/SearchForm.tsx
+++ b/src/components/SearchForm/SearchForm.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { useForm } from "react-hook-form";
 import { Search, RotateCcw, SlidersHorizontal, X } from "lucide-react";
 import { Dialog } from "@base-ui/react/dialog";
@@ -71,7 +72,7 @@ interface SearchFormProps {
   onSearch: (values: SearchFormValues) => void;
 }
 
-export function SearchForm({ values, onSearch }: SearchFormProps): JSX.Element {
+export function SearchForm({ values, onSearch }: SearchFormProps): React.JSX.Element {
   const { register, handleSubmit, reset, watch, setValue } = useForm<SearchFormValues>({
     values,
   });

--- a/src/components/SearchResults/SearchResults.tsx
+++ b/src/components/SearchResults/SearchResults.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { useQuery } from "@tanstack/react-query";
 import { fetchEvents } from "../../utils/api";
 import { Pagination } from "../Pagination/Pagination";
@@ -22,7 +23,7 @@ export function SearchResults({
   searchParams,
   onNavigate,
   onSort,
-}: SearchResultsProps): JSX.Element {
+}: SearchResultsProps): React.JSX.Element {
   const page = searchParams.page ?? 1;
   const limit = searchParams.limit ?? 100;
   const isMobile = useMediaQuery("(width <= 60rem)");

--- a/src/hooks/useAnimatedDetails.ts
+++ b/src/hooks/useAnimatedDetails.ts
@@ -1,8 +1,8 @@
-import { useRef, useCallback, type MouseEvent } from "react";
+import { useRef, useCallback, type RefObject, type MouseEvent } from "react";
 
 export function useAnimatedDetails(): {
-  ref: React.RefObject<HTMLDetailsElement>;
-  contentRef: React.RefObject<HTMLDivElement>;
+  ref: RefObject<HTMLDetailsElement | null>;
+  contentRef: RefObject<HTMLDivElement | null>;
   onSummaryClick: (e: MouseEvent) => void;
 } {
   const ref = useRef<HTMLDetailsElement>(null);

--- a/src/routes/event.$id.tsx
+++ b/src/routes/event.$id.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { createFileRoute } from "@tanstack/react-router";
 import { fetchEvents } from "../utils/api";
 import { queryClient } from "../lib/queryClient";
@@ -13,7 +14,7 @@ export const Route = createFileRoute("/event/$id")({
   component: EventDetailPage,
 });
 
-function EventDetailPage(): JSX.Element {
+function EventDetailPage(): React.JSX.Element {
   const { id } = Route.useParams();
   return (
     <main>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { createFileRoute } from "@tanstack/react-router";
 import { SearchForm } from "../components/SearchForm/SearchForm";
 import { SearchResults } from "../components/SearchResults/SearchResults";
@@ -14,7 +15,7 @@ export const Route = createFileRoute("/")({
   component: SearchPage,
 });
 
-function SearchPage(): JSX.Element {
+function SearchPage(): React.JSX.Element {
   const navigate = Route.useNavigate();
   const search = Route.useSearch();
 

--- a/src/ui/ActiveFilters/ActiveFilters.tsx
+++ b/src/ui/ActiveFilters/ActiveFilters.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import type { SearchParams } from "../../utils/types";
 import { type ActiveFilter, getActiveFilters } from "./getActiveFilters";
 import { Button } from "../Button/Button";
@@ -8,7 +9,10 @@ interface ActiveFiltersProps {
   onRemove: (filter: ActiveFilter) => void;
 }
 
-export function ActiveFilters({ searchParams, onRemove }: ActiveFiltersProps): JSX.Element | null {
+export function ActiveFilters({
+  searchParams,
+  onRemove,
+}: ActiveFiltersProps): React.JSX.Element | null {
   const filters = getActiveFilters(searchParams);
   if (filters.length === 0) {
     return null;

--- a/src/ui/AnimatedDetails/AnimatedDetails.tsx
+++ b/src/ui/AnimatedDetails/AnimatedDetails.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode, ReactEventHandler } from "react";
+import React, { type ReactNode, type ReactEventHandler } from "react";
 import { useAnimatedDetails } from "../../hooks/useAnimatedDetails";
 import styles from "./AnimatedDetails.module.css";
 
@@ -18,7 +18,7 @@ export function AnimatedDetails({
   className,
   open,
   onToggle,
-}: AnimatedDetailsProps): JSX.Element {
+}: AnimatedDetailsProps): React.JSX.Element {
   const { ref, contentRef, onSummaryClick } = useAnimatedDetails();
 
   return (

--- a/src/ui/DescriptionList/DescriptionList.tsx
+++ b/src/ui/DescriptionList/DescriptionList.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import React, { type ReactNode } from "react";
 import { clsx } from "clsx";
 import { Wanted } from "../icons/Wanted";
 import styles from "./DescriptionList.module.css";
@@ -8,7 +8,7 @@ interface DescriptionListProps {
   className?: string;
 }
 
-export function DescriptionList({ children, className }: DescriptionListProps): JSX.Element {
+export function DescriptionList({ children, className }: DescriptionListProps): React.JSX.Element {
   return <dl className={[styles.list, className].filter(Boolean).join(" ")}>{children}</dl>;
 }
 
@@ -24,7 +24,7 @@ export function DescriptionItem({
   children,
   span,
   className,
-}: DescriptionItemProps): JSX.Element {
+}: DescriptionItemProps): React.JSX.Element {
   const isEmpty = children === null || children === undefined || children === "";
 
   return (

--- a/src/ui/EmptyState/EmptyState.tsx
+++ b/src/ui/EmptyState/EmptyState.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import React, { useEffect } from "react";
 import clsx from "clsx";
 import { announce } from "../../lib/announce";
 import { Meeple } from "../icons/Meeple";
@@ -10,7 +10,7 @@ interface EmptyStateProps {
   subtext?: string;
 }
 
-export function EmptyState({ variant, text, subtext }: EmptyStateProps): JSX.Element {
+export function EmptyState({ variant, text, subtext }: EmptyStateProps): React.JSX.Element {
   useEffect(() => {
     announce(text, variant === "error" ? "assertive" : "polite");
   }, [variant, text]);

--- a/src/ui/EventTable/ColumnActionsPopover.tsx
+++ b/src/ui/EventTable/ColumnActionsPopover.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { EllipsisVertical } from "lucide-react";
 import { Popover } from "@base-ui/react/popover";
 import { Button } from "../Button/Button";
@@ -17,7 +18,7 @@ export function ColumnActionsPopover({
   activeSortDir,
   onSort,
   onOpenResize,
-}: ColumnActionsPopoverProps): JSX.Element {
+}: ColumnActionsPopoverProps): React.JSX.Element {
   const isSortedAsc =
     Boolean(sortField) && activeSortField === sortField && activeSortDir === "asc";
   const isSortedDesc =

--- a/src/ui/EventTable/ColumnControlsPanel.tsx
+++ b/src/ui/EventTable/ColumnControlsPanel.tsx
@@ -1,4 +1,4 @@
-import { useId } from "react";
+import React, { useId } from "react";
 import { ChevronRight, X } from "lucide-react";
 import { Dialog } from "@base-ui/react/dialog";
 import { Button } from "../Button/Button";
@@ -14,7 +14,11 @@ interface ColumnControlsPanelProps {
   variant?: "inline" | "drawer";
 }
 
-function ColumnCheckboxContent({ columnState }: { columnState: SharedColumnState }): JSX.Element {
+function ColumnCheckboxContent({
+  columnState,
+}: {
+  columnState: SharedColumnState;
+}): React.JSX.Element {
   const {
     visibility,
     toggleVisibility,
@@ -123,7 +127,7 @@ function ColumnCheckboxContent({ columnState }: { columnState: SharedColumnState
 export function ColumnControlsPanel({
   columnState,
   variant = "inline",
-}: ColumnControlsPanelProps): JSX.Element {
+}: ColumnControlsPanelProps): React.JSX.Element {
   if (variant === "drawer") {
     return (
       <Dialog.Root>

--- a/src/ui/EventTable/ColumnResizeDialog.tsx
+++ b/src/ui/EventTable/ColumnResizeDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useId } from "react";
+import React, { useState, useId } from "react";
 import { Dialog } from "@base-ui/react/dialog";
 import { Button } from "../Button/Button";
 import styles from "./ColumnResizeDialog.module.css";
@@ -17,7 +17,7 @@ export function ColumnResizeDialog({
   minWidth = 0,
   onApply,
   onClose,
-}: ColumnResizeDialogProps): JSX.Element {
+}: ColumnResizeDialogProps): React.JSX.Element {
   const [value, setValue] = useState(String(currentWidth));
   const inputId = useId();
 

--- a/src/ui/EventTable/EventListMobile.tsx
+++ b/src/ui/EventTable/EventListMobile.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { Link } from "@tanstack/react-router";
 import { format } from "date-fns";
 import { COLUMN_VISIBILITY_DEFAULTS } from "../../hooks/useColumnVisibility";
@@ -99,7 +100,7 @@ export function EventListMobile({
   visibility,
   typeDisplay,
   showTypeIcon,
-}: EventListMobileProps): JSX.Element {
+}: EventListMobileProps): React.JSX.Element {
   const vis = visibility ?? COLUMN_VISIBILITY_DEFAULTS;
   const isVisible = (id: string): boolean => vis[id] !== false;
 

--- a/src/ui/EventTable/EventTable.tsx
+++ b/src/ui/EventTable/EventTable.tsx
@@ -1,4 +1,4 @@
-import { useState, useId, useRef } from "react";
+import React, { useState, useId, useRef } from "react";
 import { ArrowUp, ArrowDown } from "lucide-react";
 import { createPortal } from "react-dom";
 import {
@@ -41,7 +41,7 @@ export function EventTable({
   onSort,
   sharedColumnState,
   showColumnControls = true,
-}: EventTableProps): JSX.Element {
+}: EventTableProps): React.JSX.Element {
   const internalVis = useColumnVisibility();
   const internalSizing = useColumnSizing();
   const visibility = sharedColumnState?.visibility ?? internalVis.visibility;

--- a/src/ui/EventTypeSelect/EventTypeSelect.tsx
+++ b/src/ui/EventTypeSelect/EventTypeSelect.tsx
@@ -1,4 +1,4 @@
-import { useState, useId, useRef } from "react";
+import React, { useState, useId, useRef } from "react";
 import { ChevronDown, Check } from "lucide-react";
 import { Combobox } from "@base-ui/react/combobox";
 import { EVENT_TYPES } from "../../utils/enums";
@@ -16,7 +16,7 @@ const OPTIONS = Object.entries(EVENT_TYPES).map(([code, label]) => ({
   name: label.replace(/^[A-Z]+ - /, ""),
 }));
 
-export function EventTypeSelect({ value, onValueChange }: EventTypeSelectProps): JSX.Element {
+export function EventTypeSelect({ value, onValueChange }: EventTypeSelectProps): React.JSX.Element {
   const inputId = useId();
   const inputRef = useRef<HTMLInputElement>(null);
   const [open, setOpen] = useState(false);

--- a/src/ui/Field/Field.tsx
+++ b/src/ui/Field/Field.tsx
@@ -12,7 +12,7 @@ interface FieldProps extends FieldBase {
   children: React.ReactElement;
 }
 
-export function Field({ label, children, className }: FieldProps): JSX.Element {
+export function Field({ label, children, className }: FieldProps): React.JSX.Element {
   return (
     <BaseField.Root className={clsx(styles.root, className)}>
       <BaseField.Label className={styles.label}>{label}</BaseField.Label>
@@ -27,7 +27,7 @@ function SubField({
 }: {
   label: string;
   children: React.ReactElement;
-}): JSX.Element {
+}): React.JSX.Element {
   return (
     <BaseField.Root>
       <BaseField.Label className={styles.rangeFieldLabel}>{label}</BaseField.Label>
@@ -41,7 +41,12 @@ interface RangeFieldProps extends FieldBase {
   stack?: boolean;
 }
 
-export function RangeField({ label, children, className, stack }: RangeFieldProps): JSX.Element {
+export function RangeField({
+  label,
+  children,
+  className,
+  stack,
+}: RangeFieldProps): React.JSX.Element {
   const [fromInput, toInput] = children;
   return (
     <div className={clsx(styles.root, className)}>

--- a/src/ui/Select/Select.tsx
+++ b/src/ui/Select/Select.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import clsx from "clsx";
 import styles from "./Select.module.css";
 
@@ -22,7 +23,7 @@ export function Select({
   placeholder = "Any",
   className,
   "aria-label": ariaLabel,
-}: SelectProps): JSX.Element {
+}: SelectProps): React.JSX.Element {
   return (
     <select
       value={value}

--- a/src/ui/Toggletip/Toggletip.tsx
+++ b/src/ui/Toggletip/Toggletip.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { Popover } from "@base-ui/react/popover";
 import { Button } from "../Button/Button";
 import { QuestionMark } from "../icons/QuestionMark";
@@ -8,7 +9,7 @@ interface ToggletipProps {
   message: string;
 }
 
-export function Toggletip({ label, message }: ToggletipProps): JSX.Element {
+export function Toggletip({ label, message }: ToggletipProps): React.JSX.Element {
   return (
     <Popover.Root>
       <Popover.Trigger render={<Button icon />} aria-label={label}>

--- a/src/ui/storyMatrix.test.tsx
+++ b/src/ui/storyMatrix.test.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { cartesian, makeMatrix } from "./storyMatrix";
 import type { Meta } from "@storybook/react-vite";
 
-const StubComponent = ({ children }: { children?: React.ReactNode }): JSX.Element => (
+const StubComponent = ({ children }: { children?: React.ReactNode }): React.JSX.Element => (
   <button type="button">{children}</button>
 );
 

--- a/src/ui/storyMatrix.tsx
+++ b/src/ui/storyMatrix.tsx
@@ -51,7 +51,7 @@ export function makeMatrix<TMeta extends Meta<unknown>>(
     } as StoryObj<TMeta>;
   }
 
-  function Grid(): JSX.Element {
+  function Grid(): React.JSX.Element {
     return (
       <div className={styles.grid}>
         {combos.map((combo) => {


### PR DESCRIPTION
React 19, react-dom 19, @types/react 19, @types/react-dom 19.

No deprecated API usage confirmed by pre-migration scan. @testing-library/react@16 and Storybook 10 already support React 19.

**Source changes required:** React 19 removes the global `JSX` namespace. All `JSX.Element` return type annotations were updated to `React.JSX.Element` across 25 source files. `useAnimatedDetails.ts` return type updated from `React.RefObject<T>` to `RefObject<T | null>` to match the React 19 `useRef(null)` signature.

Quality gate: lint ✓ typecheck ✓ test ✓ (612/612)